### PR TITLE
P3 - Task 3.2.3: Plan Repository (vibe-kanban)

### DIFF
--- a/internal/di/wire.go
+++ b/internal/di/wire.go
@@ -22,6 +22,7 @@ var ProviderSet = wire.NewSet(
 	// Repository providers
 	postgres.NewProjectRepository,
 	postgres.NewTaskRepository,
+	postgres.NewPlanRepository,
 	ProvideWorktreeRepository,
 	postgres.NewAuditRepository,
 	// Service providers
@@ -56,6 +57,7 @@ type App struct {
 	GormDB              *database.GormDB
 	ProjectRepo         repository.ProjectRepository
 	TaskRepo            repository.TaskRepository
+	PlanRepo            repository.PlanRepository
 	WorktreeRepo        repository.WorktreeRepository
 	AuditRepo           repository.AuditRepository
 	AuditUsecase        usecase.AuditUsecase
@@ -76,6 +78,7 @@ func NewApp(
 	gormDB *database.GormDB,
 	projectRepo repository.ProjectRepository,
 	taskRepo repository.TaskRepository,
+	planRepo repository.PlanRepository,
 	worktreeRepo repository.WorktreeRepository,
 	auditRepo repository.AuditRepository,
 	auditUsecase usecase.AuditUsecase,
@@ -93,6 +96,7 @@ func NewApp(
 		GormDB:              gormDB,
 		ProjectRepo:         projectRepo,
 		TaskRepo:            taskRepo,
+		PlanRepo:            planRepo,
 		WorktreeRepo:        worktreeRepo,
 		AuditRepo:           auditRepo,
 		AuditUsecase:        auditUsecase,

--- a/internal/entity/plan.go
+++ b/internal/entity/plan.go
@@ -1,0 +1,320 @@
+package entity
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// PlanStatus represents the status of a plan
+type PlanStatus string
+
+const (
+	PlanStatusDraft      PlanStatus = "DRAFT"
+	PlanStatusReviewing  PlanStatus = "REVIEWING"
+	PlanStatusApproved   PlanStatus = "APPROVED"
+	PlanStatusRejected   PlanStatus = "REJECTED"  
+	PlanStatusExecuting  PlanStatus = "EXECUTING"
+	PlanStatusCompleted  PlanStatus = "COMPLETED"
+	PlanStatusCancelled  PlanStatus = "CANCELLED"
+)
+
+// IsValid checks if the plan status is valid
+func (ps PlanStatus) IsValid() bool {
+	switch ps {
+	case PlanStatusDraft, PlanStatusReviewing, PlanStatusApproved, 
+		 PlanStatusRejected, PlanStatusExecuting, PlanStatusCompleted, PlanStatusCancelled:
+		return true
+	default:
+		return false
+	}
+}
+
+// String returns the string representation of PlanStatus
+func (ps PlanStatus) String() string {
+	return string(ps)
+}
+
+// GetDisplayName returns a user-friendly display name for the status
+func (ps PlanStatus) GetDisplayName() string {
+	switch ps {
+	case PlanStatusDraft:
+		return "Draft"
+	case PlanStatusReviewing:
+		return "Reviewing"
+	case PlanStatusApproved:
+		return "Approved"
+	case PlanStatusRejected:
+		return "Rejected"
+	case PlanStatusExecuting:
+		return "Executing"
+	case PlanStatusCompleted:
+		return "Completed"
+	case PlanStatusCancelled:
+		return "Cancelled"
+	default:
+		return string(ps)
+	}
+}
+
+// PlanStep represents a single step in a plan
+type PlanStep struct {
+	ID          string            `json:"id"`
+	Description string            `json:"description"`
+	Action      string            `json:"action"`
+	Parameters  map[string]string `json:"parameters"`
+	Order       int               `json:"order"`
+	Completed   bool              `json:"completed"`
+	CompletedAt *time.Time        `json:"completed_at,omitempty"`
+}
+
+// Plan represents an implementation plan for a task
+type Plan struct {
+	ID          uuid.UUID      `json:"id" gorm:"type:uuid;primary_key;default:gen_random_uuid()"`
+	TaskID      uuid.UUID      `json:"task_id" gorm:"type:uuid;not null" validate:"required"`
+	Title       string         `json:"title" gorm:"size:255;not null" validate:"required,min=1,max=255"`
+	Description string         `json:"description" gorm:"type:text" validate:"max=5000"`
+	Status      PlanStatus     `json:"status" gorm:"size:50;not null;default:'DRAFT'" validate:"required,oneof=DRAFT REVIEWING APPROVED REJECTED EXECUTING COMPLETED CANCELLED"`
+	Version     int            `json:"version" gorm:"not null;default:1"`
+	
+	// JSONB fields for complex data
+	Steps       []PlanStep        `json:"steps,omitempty" gorm:"-"`
+	StepsJSON   string            `json:"-" gorm:"column:steps;type:jsonb"`
+	Context     map[string]string `json:"context,omitempty" gorm:"-"`
+	ContextJSON string            `json:"-" gorm:"column:context;type:jsonb"`
+	
+	// Metadata
+	CreatedBy   *string        `json:"created_by,omitempty" gorm:"size:255"`
+	ApprovedBy  *string        `json:"approved_by,omitempty" gorm:"size:255"`
+	ApprovedAt  *time.Time     `json:"approved_at,omitempty"`
+	RejectedBy  *string        `json:"rejected_by,omitempty" gorm:"size:255"`
+	RejectedAt  *time.Time     `json:"rejected_at,omitempty"`
+	
+	// Timestamps
+	CreatedAt   time.Time      `json:"created_at" gorm:"autoCreateTime"`
+	UpdatedAt   time.Time      `json:"updated_at" gorm:"autoUpdateTime"`
+	DeletedAt   gorm.DeletedAt `json:"deleted_at,omitempty" gorm:"index"`
+	
+	// Relationships
+	Task        Task           `json:"task,omitempty" gorm:"foreignKey:TaskID"`
+	Versions    []PlanVersion  `json:"versions,omitempty" gorm:"foreignKey:PlanID"`
+}
+
+// PlanVersion represents a version history of a plan
+type PlanVersion struct {
+	ID          uuid.UUID      `json:"id" gorm:"type:uuid;primary_key;default:gen_random_uuid()"`
+	PlanID      uuid.UUID      `json:"plan_id" gorm:"type:uuid;not null" validate:"required"`
+	Version     int            `json:"version" gorm:"not null"`
+	Title       string         `json:"title" gorm:"size:255;not null"`
+	Description string         `json:"description" gorm:"type:text"`
+	Status      PlanStatus     `json:"status" gorm:"size:50;not null"`
+	
+	// JSONB fields for versioned data
+	Steps       []PlanStep        `json:"steps,omitempty" gorm:"-"`
+	StepsJSON   string            `json:"-" gorm:"column:steps;type:jsonb"`
+	Context     map[string]string `json:"context,omitempty" gorm:"-"`
+	ContextJSON string            `json:"-" gorm:"column:context;type:jsonb"`
+	
+	// Versioning metadata
+	CreatedBy   *string        `json:"created_by,omitempty" gorm:"size:255"`
+	ChangeLog   string         `json:"change_log,omitempty" gorm:"type:text"`
+	CreatedAt   time.Time      `json:"created_at" gorm:"autoCreateTime"`
+	
+	// Relationships
+	Plan        Plan           `json:"plan,omitempty" gorm:"foreignKey:PlanID"`
+}
+
+// GORM hooks for JSON marshaling/unmarshaling
+
+// BeforeSave marshals Steps and Context to JSON before saving
+func (p *Plan) BeforeSave(tx *gorm.DB) error {
+	if p.Steps != nil {
+		stepsJSON, err := json.Marshal(p.Steps)
+		if err != nil {
+			return err
+		}
+		p.StepsJSON = string(stepsJSON)
+	}
+	
+	if p.Context != nil {
+		contextJSON, err := json.Marshal(p.Context)
+		if err != nil {
+			return err
+		}
+		p.ContextJSON = string(contextJSON)
+	}
+	
+	return nil
+}
+
+// AfterFind unmarshals JSON to Steps and Context after loading
+func (p *Plan) AfterFind(tx *gorm.DB) error {
+	if p.StepsJSON != "" {
+		if err := json.Unmarshal([]byte(p.StepsJSON), &p.Steps); err != nil {
+			return err
+		}
+	}
+	
+	if p.ContextJSON != "" {
+		if err := json.Unmarshal([]byte(p.ContextJSON), &p.Context); err != nil {
+			return err
+		}
+	}
+	
+	return nil
+}
+
+// BeforeSave marshals Steps and Context to JSON before saving (PlanVersion)
+func (pv *PlanVersion) BeforeSave(tx *gorm.DB) error {
+	if pv.Steps != nil {
+		stepsJSON, err := json.Marshal(pv.Steps)
+		if err != nil {
+			return err
+		}
+		pv.StepsJSON = string(stepsJSON)
+	}
+	
+	if pv.Context != nil {
+		contextJSON, err := json.Marshal(pv.Context)
+		if err != nil {
+			return err
+		}
+		pv.ContextJSON = string(contextJSON)
+	}
+	
+	return nil
+}
+
+// AfterFind unmarshals JSON to Steps and Context after loading (PlanVersion)
+func (pv *PlanVersion) AfterFind(tx *gorm.DB) error {
+	if pv.StepsJSON != "" {
+		if err := json.Unmarshal([]byte(pv.StepsJSON), &pv.Steps); err != nil {
+			return err
+		}
+	}
+	
+	if pv.ContextJSON != "" {
+		if err := json.Unmarshal([]byte(pv.ContextJSON), &pv.Context); err != nil {
+			return err
+		}
+	}
+	
+	return nil
+}
+
+// CreateVersion creates a new version from the current plan
+func (p *Plan) CreateVersion(changeLog string, createdBy *string) *PlanVersion {
+	return &PlanVersion{
+		ID:          uuid.New(),
+		PlanID:      p.ID,
+		Version:     p.Version,
+		Title:       p.Title,
+		Description: p.Description,
+		Status:      p.Status,
+		Steps:       p.Steps,
+		Context:     p.Context,
+		CreatedBy:   createdBy,
+		ChangeLog:   changeLog,
+		CreatedAt:   time.Now(),
+	}
+}
+
+// GetStepByID returns a step by its ID
+func (p *Plan) GetStepByID(stepID string) *PlanStep {
+	for i := range p.Steps {
+		if p.Steps[i].ID == stepID {
+			return &p.Steps[i]
+		}
+	}
+	return nil
+}
+
+// MarkStepCompleted marks a step as completed
+func (p *Plan) MarkStepCompleted(stepID string) bool {
+	step := p.GetStepByID(stepID)
+	if step != nil {
+		step.Completed = true
+		now := time.Now()
+		step.CompletedAt = &now
+		return true
+	}
+	return false
+}
+
+// GetCompletionPercentage returns the completion percentage (0.0 to 1.0)
+func (p *Plan) GetCompletionPercentage() float64 {
+	if len(p.Steps) == 0 {
+		return 0.0
+	}
+	
+	completed := 0
+	for _, step := range p.Steps {
+		if step.Completed {
+			completed++
+		}
+	}
+	
+	return float64(completed) / float64(len(p.Steps))
+}
+
+// IsFullyCompleted returns true if all steps are completed
+func (p *Plan) IsFullyCompleted() bool {
+	if len(p.Steps) == 0 {
+		return false
+	}
+	
+	for _, step := range p.Steps {
+		if !step.Completed {
+			return false
+		}
+	}
+	
+	return true
+}
+
+// Clone creates a deep copy of the plan
+func (p *Plan) Clone() *Plan {
+	clone := *p
+	
+	// Deep copy Steps
+	if p.Steps != nil {
+		clone.Steps = make([]PlanStep, len(p.Steps))
+		copy(clone.Steps, p.Steps)
+		
+		// Deep copy Parameters in each step
+		for i := range clone.Steps {
+			if p.Steps[i].Parameters != nil {
+				clone.Steps[i].Parameters = make(map[string]string)
+				for k, v := range p.Steps[i].Parameters {
+					clone.Steps[i].Parameters[k] = v
+				}
+			}
+		}
+	}
+	
+	// Deep copy Context
+	if p.Context != nil {
+		clone.Context = make(map[string]string)
+		for k, v := range p.Context {
+			clone.Context[k] = v
+		}
+	}
+	
+	return &clone
+}
+
+// PlanFilters represents filtering options for plans
+type PlanFilters struct {
+	TaskID       *uuid.UUID
+	Statuses     []PlanStatus
+	CreatedBy    *string
+	CreatedAfter *time.Time
+	CreatedBefore *time.Time
+	SearchTerm   *string
+	Limit        *int
+	Offset       *int
+	OrderBy      *string // "created_at", "updated_at", "title", "status", "version"
+	OrderDir     *string // "asc", "desc"
+}

--- a/internal/repository/plan.go
+++ b/internal/repository/plan.go
@@ -1,0 +1,114 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/auto-devs/auto-devs/internal/entity"
+	"github.com/google/uuid"
+)
+
+// PlanRepository defines the interface for plan data access
+type PlanRepository interface {
+	// Basic CRUD operations
+	Create(ctx context.Context, plan *entity.Plan) error
+	GetByID(ctx context.Context, id uuid.UUID) (*entity.Plan, error)
+	GetByTaskID(ctx context.Context, taskID uuid.UUID) (*entity.Plan, error)
+	Update(ctx context.Context, plan *entity.Plan) error
+	Delete(ctx context.Context, id uuid.UUID) error
+	
+	// Status-based queries
+	ListByStatus(ctx context.Context, status entity.PlanStatus) ([]*entity.Plan, error)
+	UpdateStatus(ctx context.Context, id uuid.UUID, status entity.PlanStatus) error
+	
+	// Advanced filtering
+	GetPlansWithFilters(ctx context.Context, filters entity.PlanFilters) ([]*entity.Plan, error)
+	
+	// Versioning support
+	CreateVersion(ctx context.Context, planID uuid.UUID, changeLog string, createdBy *string) (*entity.PlanVersion, error)
+	GetVersions(ctx context.Context, planID uuid.UUID) ([]*entity.PlanVersion, error)
+	GetVersionByNumber(ctx context.Context, planID uuid.UUID, version int) (*entity.PlanVersion, error)
+	RollbackToVersion(ctx context.Context, planID uuid.UUID, version int, createdBy *string) error
+	CompareVersions(ctx context.Context, planID uuid.UUID, fromVersion, toVersion int) (*PlanVersionComparison, error)
+	
+	// Plan step management
+	UpdateStepStatus(ctx context.Context, planID uuid.UUID, stepID string, completed bool) error
+	GetPlanProgress(ctx context.Context, planID uuid.UUID) (*PlanProgress, error)
+	
+	// Bulk operations
+	BulkUpdateStatus(ctx context.Context, planIDs []uuid.UUID, status entity.PlanStatus) error
+	BulkDelete(ctx context.Context, planIDs []uuid.UUID) error
+	
+	// Analytics and reporting
+	GetPlanStatistics(ctx context.Context, taskID *uuid.UUID) (*PlanStatistics, error)
+	GetStatusDistribution(ctx context.Context) (map[entity.PlanStatus]int, error)
+	
+	// Validation
+	ValidatePlanExists(ctx context.Context, planID uuid.UUID) (bool, error)
+	CheckDuplicateTitle(ctx context.Context, taskID uuid.UUID, title string, excludeID *uuid.UUID) (bool, error)
+}
+
+// PlanVersionComparison represents the differences between two plan versions
+type PlanVersionComparison struct {
+	PlanID      uuid.UUID                 `json:"plan_id"`
+	FromVersion int                       `json:"from_version"`
+	ToVersion   int                       `json:"to_version"`
+	Changes     []PlanVersionChange       `json:"changes"`
+	Summary     PlanVersionChangeSummary  `json:"summary"`
+}
+
+// PlanVersionChange represents a single change between versions
+type PlanVersionChange struct {
+	Field     string      `json:"field"`      // "title", "description", "steps", "context", "status"
+	Type      string      `json:"type"`       // "added", "removed", "modified"
+	OldValue  interface{} `json:"old_value,omitempty"`
+	NewValue  interface{} `json:"new_value,omitempty"`
+	StepIndex *int        `json:"step_index,omitempty"` // For step-specific changes
+}
+
+// PlanVersionChangeSummary provides a high-level summary of changes
+type PlanVersionChangeSummary struct {
+	TotalChanges    int `json:"total_changes"`
+	StepsAdded      int `json:"steps_added"`
+	StepsRemoved    int `json:"steps_removed"`
+	StepsModified   int `json:"steps_modified"`
+	MetaDataChanges int `json:"metadata_changes"`
+}
+
+// PlanProgress represents the current progress of a plan
+type PlanProgress struct {
+	PlanID              uuid.UUID `json:"plan_id"`
+	TotalSteps          int       `json:"total_steps"`
+	CompletedSteps      int       `json:"completed_steps"`
+	CompletionPercentage float64   `json:"completion_percentage"`
+	CurrentStep         *string   `json:"current_step,omitempty"`
+	EstimatedCompletion *string   `json:"estimated_completion,omitempty"`
+}
+
+// PlanStatistics represents comprehensive statistics for plans
+type PlanStatistics struct {
+	TaskID                *uuid.UUID                   `json:"task_id,omitempty"`
+	TotalPlans            int                          `json:"total_plans"`
+	StatusDistribution    map[entity.PlanStatus]int    `json:"status_distribution"`
+	AverageStepsPerPlan   float64                      `json:"average_steps_per_plan"`
+	AverageCompletionTime *float64                     `json:"average_completion_time,omitempty"` // in hours
+	VersionStatistics     PlanVersionStatistics        `json:"version_statistics"`
+	MostActiveCreators    []PlanCreatorStats           `json:"most_active_creators"`
+}
+
+// PlanVersionStatistics represents version-related statistics
+type PlanVersionStatistics struct {
+	TotalVersions         int     `json:"total_versions"`
+	AverageVersionsPerPlan float64 `json:"average_versions_per_plan"`
+	MostVersionedPlan     *struct {
+		PlanID   uuid.UUID `json:"plan_id"`
+		Title    string    `json:"title"`
+		Versions int       `json:"versions"`
+	} `json:"most_versioned_plan,omitempty"`
+}
+
+// PlanCreatorStats represents statistics for plan creators
+type PlanCreatorStats struct {
+	CreatedBy   string `json:"created_by"`
+	PlansCount  int    `json:"plans_count"`
+	VersionsCount int  `json:"versions_count"`
+}

--- a/internal/repository/postgres/plan_repository.go
+++ b/internal/repository/postgres/plan_repository.go
@@ -1,0 +1,861 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/auto-devs/auto-devs/internal/entity"
+	"github.com/auto-devs/auto-devs/internal/repository"
+	"github.com/auto-devs/auto-devs/pkg/database"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+type planRepository struct {
+	db *database.GormDB
+}
+
+// NewPlanRepository creates a new PostgreSQL plan repository
+func NewPlanRepository(db *database.GormDB) repository.PlanRepository {
+	return &planRepository{db: db}
+}
+
+// Create creates a new plan
+func (r *planRepository) Create(ctx context.Context, plan *entity.Plan) error {
+	// Generate UUID if not provided
+	if plan.ID == uuid.Nil {
+		plan.ID = uuid.New()
+	}
+
+	// Set default status if not provided
+	if plan.Status == "" {
+		plan.Status = entity.PlanStatusDraft
+	}
+
+	// Set initial version
+	if plan.Version == 0 {
+		plan.Version = 1
+	}
+
+	// Begin transaction
+	tx := r.db.WithContext(ctx).Begin()
+	if tx.Error != nil {
+		return fmt.Errorf("failed to begin transaction: %w", tx.Error)
+	}
+	defer tx.Rollback()
+
+	// Create the plan
+	if err := tx.Create(plan).Error; err != nil {
+		return fmt.Errorf("failed to create plan: %w", err)
+	}
+
+	// Create initial version
+	version := plan.CreateVersion("Initial plan creation", plan.CreatedBy)
+	if err := tx.Create(version).Error; err != nil {
+		return fmt.Errorf("failed to create initial plan version: %w", err)
+	}
+
+	return tx.Commit().Error
+}
+
+// GetByID retrieves a plan by ID
+func (r *planRepository) GetByID(ctx context.Context, id uuid.UUID) (*entity.Plan, error) {
+	var plan entity.Plan
+
+	result := r.db.WithContext(ctx).Preload("Task").First(&plan, "id = ?", id)
+	if result.Error != nil {
+		if result.Error == gorm.ErrRecordNotFound {
+			return nil, fmt.Errorf("plan not found with id %s", id)
+		}
+		return nil, fmt.Errorf("failed to get plan: %w", result.Error)
+	}
+
+	return &plan, nil
+}
+
+// GetByTaskID retrieves a plan by task ID
+func (r *planRepository) GetByTaskID(ctx context.Context, taskID uuid.UUID) (*entity.Plan, error) {
+	var plan entity.Plan
+
+	result := r.db.WithContext(ctx).Preload("Task").Where("task_id = ?", taskID).First(&plan)
+	if result.Error != nil {
+		if result.Error == gorm.ErrRecordNotFound {
+			return nil, fmt.Errorf("plan not found for task %s", taskID)
+		}
+		return nil, fmt.Errorf("failed to get plan by task ID: %w", result.Error)
+	}
+
+	return &plan, nil
+}
+
+// Update updates an existing plan
+func (r *planRepository) Update(ctx context.Context, plan *entity.Plan) error {
+	// Begin transaction
+	tx := r.db.WithContext(ctx).Begin()
+	if tx.Error != nil {
+		return fmt.Errorf("failed to begin transaction: %w", tx.Error)
+	}
+	defer tx.Rollback()
+
+	// Get existing plan to compare for versioning
+	var existingPlan entity.Plan
+	if err := tx.First(&existingPlan, "id = ?", plan.ID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return fmt.Errorf("plan not found with id %s", plan.ID)
+		}
+		return fmt.Errorf("failed to get existing plan: %w", err)
+	}
+
+	// Check if significant changes were made that warrant a new version
+	shouldCreateVersion := r.shouldCreateNewVersion(&existingPlan, plan)
+	
+	if shouldCreateVersion {
+		// Create new version before updating
+		version := existingPlan.CreateVersion("Plan updated", plan.CreatedBy)
+		if err := tx.Create(version).Error; err != nil {
+			return fmt.Errorf("failed to create plan version: %w", err)
+		}
+
+		// Increment version number
+		plan.Version = existingPlan.Version + 1
+	}
+
+	// Update the plan
+	if err := tx.Save(plan).Error; err != nil {
+		return fmt.Errorf("failed to update plan: %w", err)
+	}
+
+	return tx.Commit().Error
+}
+
+// Delete soft deletes a plan by ID
+func (r *planRepository) Delete(ctx context.Context, id uuid.UUID) error {
+	result := r.db.WithContext(ctx).Delete(&entity.Plan{}, "id = ?", id)
+	if result.Error != nil {
+		return fmt.Errorf("failed to delete plan: %w", result.Error)
+	}
+
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("plan not found with id %s", id)
+	}
+
+	return nil
+}
+
+// ListByStatus retrieves plans by status
+func (r *planRepository) ListByStatus(ctx context.Context, status entity.PlanStatus) ([]*entity.Plan, error) {
+	var plans []entity.Plan
+
+	result := r.db.WithContext(ctx).
+		Preload("Task").
+		Where("status = ?", status).
+		Order("created_at DESC").
+		Find(&plans)
+	
+	if result.Error != nil {
+		return nil, fmt.Errorf("failed to get plans by status: %w", result.Error)
+	}
+
+	// Convert to slice of pointers
+	planPtrs := make([]*entity.Plan, len(plans))
+	for i := range plans {
+		planPtrs[i] = &plans[i]
+	}
+
+	return planPtrs, nil
+}
+
+// UpdateStatus updates the status of a plan
+func (r *planRepository) UpdateStatus(ctx context.Context, id uuid.UUID, status entity.PlanStatus) error {
+	// Begin transaction to update status and create version if needed
+	tx := r.db.WithContext(ctx).Begin()
+	if tx.Error != nil {
+		return fmt.Errorf("failed to begin transaction: %w", tx.Error)
+	}
+	defer tx.Rollback()
+
+	// Get current plan
+	var plan entity.Plan
+	if err := tx.First(&plan, "id = ?", id).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return fmt.Errorf("plan not found with id %s", id)
+		}
+		return fmt.Errorf("failed to get plan: %w", err)
+	}
+
+	// Update status with appropriate metadata
+	updates := map[string]interface{}{
+		"status": status,
+	}
+
+	now := time.Now()
+	switch status {
+	case entity.PlanStatusApproved:
+		updates["approved_at"] = &now
+	case entity.PlanStatusRejected:
+		updates["rejected_at"] = &now
+	}
+
+	if err := tx.Model(&plan).Updates(updates).Error; err != nil {
+		return fmt.Errorf("failed to update plan status: %w", err)
+	}
+
+	// Create version for status changes
+	version := plan.CreateVersion(fmt.Sprintf("Status changed to %s", status), nil)
+	if err := tx.Create(version).Error; err != nil {
+		return fmt.Errorf("failed to create version for status change: %w", err)
+	}
+
+	return tx.Commit().Error
+}
+
+// GetPlansWithFilters retrieves plans with advanced filtering
+func (r *planRepository) GetPlansWithFilters(ctx context.Context, filters entity.PlanFilters) ([]*entity.Plan, error) {
+	query := r.db.WithContext(ctx).Preload("Task")
+
+	// Apply filters
+	if filters.TaskID != nil {
+		query = query.Where("task_id = ?", *filters.TaskID)
+	}
+
+	if len(filters.Statuses) > 0 {
+		query = query.Where("status IN ?", filters.Statuses)
+	}
+
+	if filters.CreatedBy != nil {
+		query = query.Where("created_by = ?", *filters.CreatedBy)
+	}
+
+	if filters.CreatedAfter != nil {
+		query = query.Where("created_at >= ?", *filters.CreatedAfter)
+	}
+
+	if filters.CreatedBefore != nil {
+		query = query.Where("created_at <= ?", *filters.CreatedBefore)
+	}
+
+	if filters.SearchTerm != nil && *filters.SearchTerm != "" {
+		searchTerm := "%" + *filters.SearchTerm + "%"
+		query = query.Where("title ILIKE ? OR description ILIKE ?", searchTerm, searchTerm)
+	}
+
+	// Apply ordering
+	orderBy := "created_at"
+	if filters.OrderBy != nil {
+		orderBy = *filters.OrderBy
+	}
+
+	orderDir := "DESC"
+	if filters.OrderDir != nil {
+		orderDir = strings.ToUpper(*filters.OrderDir)
+	}
+
+	query = query.Order(fmt.Sprintf("%s %s", orderBy, orderDir))
+
+	// Apply pagination
+	if filters.Offset != nil {
+		query = query.Offset(*filters.Offset)
+	}
+
+	if filters.Limit != nil {
+		query = query.Limit(*filters.Limit)
+	}
+
+	var plans []entity.Plan
+	if err := query.Find(&plans).Error; err != nil {
+		return nil, fmt.Errorf("failed to get plans with filters: %w", err)
+	}
+
+	// Convert to slice of pointers
+	planPtrs := make([]*entity.Plan, len(plans))
+	for i := range plans {
+		planPtrs[i] = &plans[i]
+	}
+
+	return planPtrs, nil
+}
+
+// CreateVersion creates a new version of a plan
+func (r *planRepository) CreateVersion(ctx context.Context, planID uuid.UUID, changeLog string, createdBy *string) (*entity.PlanVersion, error) {
+	// Get current plan
+	var plan entity.Plan
+	if err := r.db.WithContext(ctx).First(&plan, "id = ?", planID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, fmt.Errorf("plan not found with id %s", planID)
+		}
+		return nil, fmt.Errorf("failed to get plan: %w", err)
+	}
+
+	// Create new version
+	version := plan.CreateVersion(changeLog, createdBy)
+	
+	if err := r.db.WithContext(ctx).Create(version).Error; err != nil {
+		return nil, fmt.Errorf("failed to create plan version: %w", err)
+	}
+
+	return version, nil
+}
+
+// GetVersions retrieves all versions of a plan
+func (r *planRepository) GetVersions(ctx context.Context, planID uuid.UUID) ([]*entity.PlanVersion, error) {
+	var versions []entity.PlanVersion
+
+	result := r.db.WithContext(ctx).
+		Where("plan_id = ?", planID).
+		Order("version DESC").
+		Find(&versions)
+	
+	if result.Error != nil {
+		return nil, fmt.Errorf("failed to get plan versions: %w", result.Error)
+	}
+
+	// Convert to slice of pointers
+	versionPtrs := make([]*entity.PlanVersion, len(versions))
+	for i := range versions {
+		versionPtrs[i] = &versions[i]
+	}
+
+	return versionPtrs, nil
+}
+
+// GetVersionByNumber retrieves a specific version of a plan
+func (r *planRepository) GetVersionByNumber(ctx context.Context, planID uuid.UUID, version int) (*entity.PlanVersion, error) {
+	var planVersion entity.PlanVersion
+
+	result := r.db.WithContext(ctx).
+		Where("plan_id = ? AND version = ?", planID, version).
+		First(&planVersion)
+	
+	if result.Error != nil {
+		if result.Error == gorm.ErrRecordNotFound {
+			return nil, fmt.Errorf("plan version %d not found for plan %s", version, planID)
+		}
+		return nil, fmt.Errorf("failed to get plan version: %w", result.Error)
+	}
+
+	return &planVersion, nil
+}
+
+// RollbackToVersion rolls back a plan to a specific version
+func (r *planRepository) RollbackToVersion(ctx context.Context, planID uuid.UUID, version int, createdBy *string) error {
+	// Begin transaction
+	tx := r.db.WithContext(ctx).Begin()
+	if tx.Error != nil {
+		return fmt.Errorf("failed to begin transaction: %w", tx.Error)
+	}
+	defer tx.Rollback()
+
+	// Get target version
+	var targetVersion entity.PlanVersion
+	if err := tx.Where("plan_id = ? AND version = ?", planID, version).First(&targetVersion).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return fmt.Errorf("plan version %d not found for plan %s", version, planID)
+		}
+		return fmt.Errorf("failed to get target version: %w", err)
+	}
+
+	// Get current plan
+	var currentPlan entity.Plan
+	if err := tx.First(&currentPlan, "id = ?", planID).Error; err != nil {
+		return fmt.Errorf("failed to get current plan: %w", err)
+	}
+
+	// Create a version from current plan before rollback
+	rollbackVersion := currentPlan.CreateVersion(fmt.Sprintf("Rollback to version %d", version), createdBy)
+	if err := tx.Create(rollbackVersion).Error; err != nil {
+		return fmt.Errorf("failed to create rollback version: %w", err)
+	}
+
+	// Update plan with target version data
+	updates := map[string]interface{}{
+		"title":       targetVersion.Title,
+		"description": targetVersion.Description,
+		"status":      targetVersion.Status,
+		"steps":       targetVersion.StepsJSON,
+		"context":     targetVersion.ContextJSON,
+		"version":     currentPlan.Version + 1,
+	}
+
+	if err := tx.Model(&currentPlan).Updates(updates).Error; err != nil {
+		return fmt.Errorf("failed to rollback plan: %w", err)
+	}
+
+	return tx.Commit().Error
+}
+
+// CompareVersions compares two versions of a plan
+func (r *planRepository) CompareVersions(ctx context.Context, planID uuid.UUID, fromVersion, toVersion int) (*repository.PlanVersionComparison, error) {
+	// Get both versions
+	var fromVer, toVer entity.PlanVersion
+	
+	if err := r.db.WithContext(ctx).Where("plan_id = ? AND version = ?", planID, fromVersion).First(&fromVer).Error; err != nil {
+		return nil, fmt.Errorf("failed to get from version: %w", err)
+	}
+
+	if err := r.db.WithContext(ctx).Where("plan_id = ? AND version = ?", planID, toVersion).First(&toVer).Error; err != nil {
+		return nil, fmt.Errorf("failed to get to version: %w", err)
+	}
+
+	// Compare and generate changes
+	changes := r.compareVersionData(&fromVer, &toVer)
+	
+	// Generate summary
+	summary := r.generateChangeSummary(changes)
+
+	return &repository.PlanVersionComparison{
+		PlanID:      planID,
+		FromVersion: fromVersion,
+		ToVersion:   toVersion,
+		Changes:     changes,
+		Summary:     summary,
+	}, nil
+}
+
+// UpdateStepStatus updates the completion status of a specific step
+func (r *planRepository) UpdateStepStatus(ctx context.Context, planID uuid.UUID, stepID string, completed bool) error {
+	// Get current plan
+	var plan entity.Plan
+	if err := r.db.WithContext(ctx).First(&plan, "id = ?", planID).Error; err != nil {
+		return fmt.Errorf("failed to get plan: %w", err)
+	}
+
+	// Update step status
+	updated := false
+	if completed {
+		updated = plan.MarkStepCompleted(stepID)
+	} else {
+		step := plan.GetStepByID(stepID)
+		if step != nil {
+			step.Completed = false
+			step.CompletedAt = nil
+			updated = true
+		}
+	}
+
+	if !updated {
+		return fmt.Errorf("step not found with id %s", stepID)
+	}
+
+	// Save updated plan
+	if err := r.db.WithContext(ctx).Save(&plan).Error; err != nil {
+		return fmt.Errorf("failed to update step status: %w", err)
+	}
+
+	return nil
+}
+
+// GetPlanProgress retrieves the current progress of a plan
+func (r *planRepository) GetPlanProgress(ctx context.Context, planID uuid.UUID) (*repository.PlanProgress, error) {
+	var plan entity.Plan
+	if err := r.db.WithContext(ctx).First(&plan, "id = ?", planID).Error; err != nil {
+		return nil, fmt.Errorf("failed to get plan: %w", err)
+	}
+
+	completedSteps := 0
+	var currentStep *string
+	
+	for _, step := range plan.Steps {
+		if step.Completed {
+			completedSteps++
+		} else if currentStep == nil {
+			// First incomplete step is the current step
+			currentStep = &step.Description
+		}
+	}
+
+	return &repository.PlanProgress{
+		PlanID:              planID,
+		TotalSteps:          len(plan.Steps),
+		CompletedSteps:      completedSteps,
+		CompletionPercentage: plan.GetCompletionPercentage(),
+		CurrentStep:         currentStep,
+	}, nil
+}
+
+// BulkUpdateStatus updates the status of multiple plans
+func (r *planRepository) BulkUpdateStatus(ctx context.Context, planIDs []uuid.UUID, status entity.PlanStatus) error {
+	if len(planIDs) == 0 {
+		return nil
+	}
+
+	updates := map[string]interface{}{
+		"status": status,
+	}
+
+	now := time.Now()
+	switch status {
+	case entity.PlanStatusApproved:
+		updates["approved_at"] = &now
+	case entity.PlanStatusRejected:
+		updates["rejected_at"] = &now
+	}
+
+	result := r.db.WithContext(ctx).Model(&entity.Plan{}).Where("id IN ?", planIDs).Updates(updates)
+	if result.Error != nil {
+		return fmt.Errorf("failed to bulk update plan status: %w", result.Error)
+	}
+
+	return nil
+}
+
+// BulkDelete soft deletes multiple plans
+func (r *planRepository) BulkDelete(ctx context.Context, planIDs []uuid.UUID) error {
+	if len(planIDs) == 0 {
+		return nil
+	}
+
+	result := r.db.WithContext(ctx).Delete(&entity.Plan{}, "id IN ?", planIDs)
+	if result.Error != nil {
+		return fmt.Errorf("failed to bulk delete plans: %w", result.Error)
+	}
+
+	return nil
+}
+
+// GetPlanStatistics retrieves comprehensive statistics for plans
+func (r *planRepository) GetPlanStatistics(ctx context.Context, taskID *uuid.UUID) (*repository.PlanStatistics, error) {
+	query := r.db.WithContext(ctx).Model(&entity.Plan{})
+	
+	if taskID != nil {
+		query = query.Where("task_id = ?", *taskID)
+	}
+
+	// Get total count
+	var totalPlans int64
+	if err := query.Count(&totalPlans).Error; err != nil {
+		return nil, fmt.Errorf("failed to count plans: %w", err)
+	}
+
+	// Get status distribution
+	statusDist, err := r.GetStatusDistribution(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get status distribution: %w", err)
+	}
+
+	// Calculate average steps per plan
+	var avgSteps float64
+	if totalPlans > 0 {
+		var plans []entity.Plan
+		if err := query.Find(&plans).Error; err != nil {
+			return nil, fmt.Errorf("failed to get plans for statistics: %w", err)
+		}
+
+		totalSteps := 0
+		for _, plan := range plans {
+			totalSteps += len(plan.Steps)
+		}
+		avgSteps = float64(totalSteps) / float64(totalPlans)
+	}
+
+	// Get version statistics
+	versionStats, err := r.getVersionStatistics(ctx, taskID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get version statistics: %w", err)
+	}
+
+	return &repository.PlanStatistics{
+		TaskID:                taskID,
+		TotalPlans:            int(totalPlans),
+		StatusDistribution:    statusDist,
+		AverageStepsPerPlan:   avgSteps,
+		VersionStatistics:     *versionStats,
+	}, nil
+}
+
+// GetStatusDistribution retrieves the distribution of plans by status
+func (r *planRepository) GetStatusDistribution(ctx context.Context) (map[entity.PlanStatus]int, error) {
+	var results []struct {
+		Status entity.PlanStatus
+		Count  int
+	}
+
+	err := r.db.WithContext(ctx).
+		Model(&entity.Plan{}).
+		Select("status, count(*) as count").
+		Group("status").
+		Find(&results).Error
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to get status distribution: %w", err)
+	}
+
+	distribution := make(map[entity.PlanStatus]int)
+	for _, result := range results {
+		distribution[result.Status] = result.Count
+	}
+
+	return distribution, nil
+}
+
+// ValidatePlanExists checks if a plan exists
+func (r *planRepository) ValidatePlanExists(ctx context.Context, planID uuid.UUID) (bool, error) {
+	var count int64
+	err := r.db.WithContext(ctx).Model(&entity.Plan{}).Where("id = ?", planID).Count(&count).Error
+	if err != nil {
+		return false, fmt.Errorf("failed to validate plan existence: %w", err)
+	}
+	return count > 0, nil
+}
+
+// CheckDuplicateTitle checks if a plan title already exists for the task
+func (r *planRepository) CheckDuplicateTitle(ctx context.Context, taskID uuid.UUID, title string, excludeID *uuid.UUID) (bool, error) {
+	query := r.db.WithContext(ctx).Model(&entity.Plan{}).Where("task_id = ? AND title = ?", taskID, title)
+	
+	if excludeID != nil {
+		query = query.Where("id != ?", *excludeID)
+	}
+
+	var count int64
+	if err := query.Count(&count).Error; err != nil {
+		return false, fmt.Errorf("failed to check duplicate title: %w", err)
+	}
+
+	return count > 0, nil
+}
+
+// Helper methods
+
+// shouldCreateNewVersion determines if changes warrant a new version
+func (r *planRepository) shouldCreateNewVersion(old, new *entity.Plan) bool {
+	// Check if title, description, or steps changed
+	if old.Title != new.Title || old.Description != new.Description {
+		return true
+	}
+
+	// Check if steps changed
+	if !r.stepsEqual(old.Steps, new.Steps) {
+		return true
+	}
+
+	// Check if context changed significantly
+	if !r.contextEqual(old.Context, new.Context) {
+		return true
+	}
+
+	return false
+}
+
+// stepsEqual compares two step slices for equality
+func (r *planRepository) stepsEqual(a, b []entity.PlanStep) bool {
+	if len(a) != len(b) {
+		return true // Different length means changes
+	}
+
+	for i := range a {
+		if a[i].Description != b[i].Description || 
+		   a[i].Action != b[i].Action || 
+		   a[i].Order != b[i].Order {
+			return false
+		}
+		
+		// Check parameters
+		if !reflect.DeepEqual(a[i].Parameters, b[i].Parameters) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// contextEqual compares two context maps for equality
+func (r *planRepository) contextEqual(a, b map[string]string) bool {
+	return reflect.DeepEqual(a, b)
+}
+
+// compareVersionData compares two plan versions and returns changes
+func (r *planRepository) compareVersionData(from, to *entity.PlanVersion) []repository.PlanVersionChange {
+	var changes []repository.PlanVersionChange
+
+	// Compare title
+	if from.Title != to.Title {
+		changes = append(changes, repository.PlanVersionChange{
+			Field:    "title",
+			Type:     "modified",
+			OldValue: from.Title,
+			NewValue: to.Title,
+		})
+	}
+
+	// Compare description
+	if from.Description != to.Description {
+		changes = append(changes, repository.PlanVersionChange{
+			Field:    "description",
+			Type:     "modified",
+			OldValue: from.Description,
+			NewValue: to.Description,
+		})
+	}
+
+	// Compare status
+	if from.Status != to.Status {
+		changes = append(changes, repository.PlanVersionChange{
+			Field:    "status",
+			Type:     "modified",
+			OldValue: from.Status,
+			NewValue: to.Status,
+		})
+	}
+
+	// Compare steps
+	stepChanges := r.compareSteps(from.Steps, to.Steps)
+	changes = append(changes, stepChanges...)
+
+	// Compare context
+	contextChanges := r.compareContext(from.Context, to.Context)
+	changes = append(changes, contextChanges...)
+
+	return changes
+}
+
+// compareSteps compares steps between versions
+func (r *planRepository) compareSteps(fromSteps, toSteps []entity.PlanStep) []repository.PlanVersionChange {
+	var changes []repository.PlanVersionChange
+
+	// Create maps for easier comparison
+	fromMap := make(map[string]entity.PlanStep)
+	toMap := make(map[string]entity.PlanStep)
+
+	for _, step := range fromSteps {
+		fromMap[step.ID] = step
+	}
+
+	for _, step := range toSteps {
+		toMap[step.ID] = step
+	}
+
+	// Find added steps
+	for id, step := range toMap {
+		if _, exists := fromMap[id]; !exists {
+			changes = append(changes, repository.PlanVersionChange{
+				Field:    "steps",
+				Type:     "added",
+				NewValue: step,
+			})
+		}
+	}
+
+	// Find removed and modified steps
+	for id, fromStep := range fromMap {
+		if toStep, exists := toMap[id]; !exists {
+			// Step removed
+			changes = append(changes, repository.PlanVersionChange{
+				Field:    "steps",
+				Type:     "removed",
+				OldValue: fromStep,
+			})
+		} else if !reflect.DeepEqual(fromStep, toStep) {
+			// Step modified
+			changes = append(changes, repository.PlanVersionChange{
+				Field:    "steps",
+				Type:     "modified",
+				OldValue: fromStep,
+				NewValue: toStep,
+			})
+		}
+	}
+
+	return changes
+}
+
+// compareContext compares context between versions
+func (r *planRepository) compareContext(fromContext, toContext map[string]string) []repository.PlanVersionChange {
+	var changes []repository.PlanVersionChange
+
+	// Find added and modified context
+	for key, toValue := range toContext {
+		if fromValue, exists := fromContext[key]; !exists {
+			changes = append(changes, repository.PlanVersionChange{
+				Field:    "context",
+				Type:     "added",
+				NewValue: map[string]string{key: toValue},
+			})
+		} else if fromValue != toValue {
+			changes = append(changes, repository.PlanVersionChange{
+				Field:    "context",
+				Type:     "modified",
+				OldValue: map[string]string{key: fromValue},
+				NewValue: map[string]string{key: toValue},
+			})
+		}
+	}
+
+	// Find removed context
+	for key, fromValue := range fromContext {
+		if _, exists := toContext[key]; !exists {
+			changes = append(changes, repository.PlanVersionChange{
+				Field:    "context",
+				Type:     "removed",
+				OldValue: map[string]string{key: fromValue},
+			})
+		}
+	}
+
+	return changes
+}
+
+// generateChangeSummary generates a summary from changes
+func (r *planRepository) generateChangeSummary(changes []repository.PlanVersionChange) repository.PlanVersionChangeSummary {
+	summary := repository.PlanVersionChangeSummary{
+		TotalChanges: len(changes),
+	}
+
+	for _, change := range changes {
+		switch change.Field {
+		case "steps":
+			switch change.Type {
+			case "added":
+				summary.StepsAdded++
+			case "removed":
+				summary.StepsRemoved++
+			case "modified":
+				summary.StepsModified++
+			}
+		default:
+			summary.MetaDataChanges++
+		}
+	}
+
+	return summary
+}
+
+// getVersionStatistics calculates version-related statistics
+func (r *planRepository) getVersionStatistics(ctx context.Context, taskID *uuid.UUID) (*repository.PlanVersionStatistics, error) {
+	query := r.db.WithContext(ctx).Model(&entity.PlanVersion{})
+	
+	if taskID != nil {
+		query = query.Joins("JOIN plans ON plan_versions.plan_id = plans.id").
+			Where("plans.task_id = ?", *taskID)
+	}
+
+	// Get total versions
+	var totalVersions int64
+	if err := query.Count(&totalVersions).Error; err != nil {
+		return nil, fmt.Errorf("failed to count versions: %w", err)
+	}
+
+	// Get total plans for average calculation
+	planQuery := r.db.WithContext(ctx).Model(&entity.Plan{})
+	if taskID != nil {
+		planQuery = planQuery.Where("task_id = ?", *taskID)
+	}
+
+	var totalPlans int64
+	if err := planQuery.Count(&totalPlans).Error; err != nil {
+		return nil, fmt.Errorf("failed to count plans: %w", err)
+	}
+
+	avgVersions := float64(0)
+	if totalPlans > 0 {
+		avgVersions = float64(totalVersions) / float64(totalPlans)
+	}
+
+	return &repository.PlanVersionStatistics{
+		TotalVersions:         int(totalVersions),
+		AverageVersionsPerPlan: avgVersions,
+	}, nil
+}

--- a/migrations/000011_add_plan_tables.down.sql
+++ b/migrations/000011_add_plan_tables.down.sql
@@ -1,0 +1,32 @@
+-- Drop the trigger and function
+DROP TRIGGER IF EXISTS create_plan_version_trigger ON plans;
+DROP FUNCTION IF EXISTS create_plan_version_on_update();
+
+-- Drop indexes
+DROP INDEX IF EXISTS idx_plans_task_id;
+DROP INDEX IF EXISTS idx_plans_status;
+DROP INDEX IF EXISTS idx_plans_created_by;
+DROP INDEX IF EXISTS idx_plans_approved_by;
+DROP INDEX IF EXISTS idx_plans_rejected_by;
+DROP INDEX IF EXISTS idx_plans_created_at;
+DROP INDEX IF EXISTS idx_plans_updated_at;
+DROP INDEX IF EXISTS idx_plans_deleted_at;
+
+DROP INDEX IF EXISTS idx_plan_versions_plan_id;
+DROP INDEX IF EXISTS idx_plan_versions_version;
+DROP INDEX IF EXISTS idx_plan_versions_created_by;
+DROP INDEX IF EXISTS idx_plan_versions_created_at;
+DROP INDEX IF EXISTS idx_plan_versions_unique;
+
+-- Drop GIN indexes for JSONB fields
+DROP INDEX IF EXISTS idx_plans_steps_gin;
+DROP INDEX IF EXISTS idx_plans_context_gin;
+DROP INDEX IF EXISTS idx_plan_versions_steps_gin;
+DROP INDEX IF EXISTS idx_plan_versions_context_gin;
+
+-- Drop triggers
+DROP TRIGGER IF EXISTS update_plans_updated_at ON plans;
+
+-- Drop tables (plan_versions first due to foreign key constraint)
+DROP TABLE IF EXISTS plan_versions;
+DROP TABLE IF EXISTS plans;

--- a/migrations/000011_add_plan_tables.up.sql
+++ b/migrations/000011_add_plan_tables.up.sql
@@ -1,0 +1,193 @@
+-- Create plans table for AI implementation plans
+CREATE TABLE plans (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    task_id UUID NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+    title VARCHAR(255) NOT NULL,
+    description TEXT,
+    status VARCHAR(50) NOT NULL DEFAULT 'DRAFT',
+    version INTEGER NOT NULL DEFAULT 1,
+    
+    -- JSONB fields for complex data
+    steps JSONB DEFAULT '[]'::jsonb,
+    context JSONB DEFAULT '{}'::jsonb,
+    
+    -- Metadata
+    created_by VARCHAR(255),
+    approved_by VARCHAR(255),
+    approved_at TIMESTAMP WITH TIME ZONE,
+    rejected_by VARCHAR(255),
+    rejected_at TIMESTAMP WITH TIME ZONE,
+    
+    -- Standard timestamps
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    deleted_at TIMESTAMP WITH TIME ZONE NULL
+);
+
+-- Create plan_versions table for plan versioning
+CREATE TABLE plan_versions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    plan_id UUID NOT NULL REFERENCES plans(id) ON DELETE CASCADE,
+    version INTEGER NOT NULL,
+    title VARCHAR(255) NOT NULL,
+    description TEXT,
+    status VARCHAR(50) NOT NULL,
+    
+    -- JSONB fields for versioned data
+    steps JSONB DEFAULT '[]'::jsonb,
+    context JSONB DEFAULT '{}'::jsonb,
+    
+    -- Versioning metadata
+    created_by VARCHAR(255),
+    change_log TEXT,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Create indexes for better performance
+CREATE INDEX idx_plans_task_id ON plans(task_id);
+CREATE INDEX idx_plans_status ON plans(status);
+CREATE INDEX idx_plans_created_by ON plans(created_by);
+CREATE INDEX idx_plans_approved_by ON plans(approved_by);
+CREATE INDEX idx_plans_rejected_by ON plans(rejected_by);
+CREATE INDEX idx_plans_created_at ON plans(created_at);
+CREATE INDEX idx_plans_updated_at ON plans(updated_at);
+CREATE INDEX idx_plans_deleted_at ON plans(deleted_at);
+
+-- Indexes for plan_versions
+CREATE INDEX idx_plan_versions_plan_id ON plan_versions(plan_id);
+CREATE INDEX idx_plan_versions_version ON plan_versions(version);
+CREATE INDEX idx_plan_versions_created_by ON plan_versions(created_by);
+CREATE INDEX idx_plan_versions_created_at ON plan_versions(created_at);
+
+-- Unique constraint for plan versions
+CREATE UNIQUE INDEX idx_plan_versions_unique ON plan_versions(plan_id, version);
+
+-- GIN indexes for JSONB fields for better search performance
+CREATE INDEX idx_plans_steps_gin ON plans USING GIN (steps);
+CREATE INDEX idx_plans_context_gin ON plans USING GIN (context);
+CREATE INDEX idx_plan_versions_steps_gin ON plan_versions USING GIN (steps);
+CREATE INDEX idx_plan_versions_context_gin ON plan_versions USING GIN (context);
+
+-- Add check constraints for valid status values
+ALTER TABLE plans 
+ADD CONSTRAINT valid_plan_status CHECK (
+    status IN ('DRAFT', 'REVIEWING', 'APPROVED', 'REJECTED', 'EXECUTING', 'COMPLETED', 'CANCELLED')
+);
+
+ALTER TABLE plan_versions 
+ADD CONSTRAINT valid_plan_version_status CHECK (
+    status IN ('DRAFT', 'REVIEWING', 'APPROVED', 'REJECTED', 'EXECUTING', 'COMPLETED', 'CANCELLED')
+);
+
+-- Add check constraints for version numbers
+ALTER TABLE plans
+ADD CONSTRAINT valid_plan_version CHECK (version > 0);
+
+ALTER TABLE plan_versions
+ADD CONSTRAINT valid_plan_version_number CHECK (version > 0);
+
+-- Create trigger for auto-updating updated_at column
+CREATE TRIGGER update_plans_updated_at 
+    BEFORE UPDATE ON plans 
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- Add comments for documentation
+COMMENT ON TABLE plans IS 'AI implementation plans for tasks';
+COMMENT ON COLUMN plans.task_id IS 'Reference to the task this plan belongs to';
+COMMENT ON COLUMN plans.title IS 'Title of the implementation plan';
+COMMENT ON COLUMN plans.description IS 'Detailed description of the plan';
+COMMENT ON COLUMN plans.status IS 'Plan status: DRAFT, REVIEWING, APPROVED, REJECTED, EXECUTING, COMPLETED, CANCELLED';
+COMMENT ON COLUMN plans.version IS 'Current version number of the plan';
+COMMENT ON COLUMN plans.steps IS 'Implementation steps as JSONB array';
+COMMENT ON COLUMN plans.context IS 'Plan context and metadata as JSONB object';
+COMMENT ON COLUMN plans.created_by IS 'User or system that created the plan';
+COMMENT ON COLUMN plans.approved_by IS 'User who approved the plan';
+COMMENT ON COLUMN plans.approved_at IS 'Timestamp when plan was approved';
+COMMENT ON COLUMN plans.rejected_by IS 'User who rejected the plan';
+COMMENT ON COLUMN plans.rejected_at IS 'Timestamp when plan was rejected';
+
+COMMENT ON TABLE plan_versions IS 'Version history for implementation plans';
+COMMENT ON COLUMN plan_versions.plan_id IS 'Reference to the parent plan';
+COMMENT ON COLUMN plan_versions.version IS 'Version number of this plan version';
+COMMENT ON COLUMN plan_versions.title IS 'Title of the plan at this version';
+COMMENT ON COLUMN plan_versions.description IS 'Description of the plan at this version';
+COMMENT ON COLUMN plan_versions.status IS 'Status of the plan at this version';
+COMMENT ON COLUMN plan_versions.steps IS 'Implementation steps at this version as JSONB array';
+COMMENT ON COLUMN plan_versions.context IS 'Plan context at this version as JSONB object';
+COMMENT ON COLUMN plan_versions.created_by IS 'User who created this version';
+COMMENT ON COLUMN plan_versions.change_log IS 'Description of changes made in this version';
+
+-- Create a function to automatically create plan versions on significant updates
+CREATE OR REPLACE FUNCTION create_plan_version_on_update()
+RETURNS TRIGGER AS $$
+BEGIN
+    -- Only create version if title, description, steps, or context changed
+    IF OLD.title != NEW.title OR 
+       OLD.description != NEW.description OR 
+       OLD.steps != NEW.steps OR 
+       OLD.context != NEW.context THEN
+        
+        INSERT INTO plan_versions (
+            plan_id, 
+            version, 
+            title, 
+            description, 
+            status, 
+            steps, 
+            context, 
+            created_by,
+            change_log
+        ) VALUES (
+            OLD.id,
+            OLD.version,
+            OLD.title,
+            OLD.description,
+            OLD.status,
+            OLD.steps,
+            OLD.context,
+            NEW.created_by,
+            'Automatic version created on plan update'
+        );
+    END IF;
+    
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Note: The trigger for auto-versioning is commented out as it's handled in the application layer
+-- This gives more control over when versions are created
+-- CREATE TRIGGER create_plan_version_trigger
+--     AFTER UPDATE ON plans
+--     FOR EACH ROW EXECUTE FUNCTION create_plan_version_on_update();
+
+-- Example JSONB structure for steps field:
+-- [
+--   {
+--     "id": "step-1",
+--     "description": "Analyze requirements",
+--     "action": "analysis",
+--     "parameters": {"type": "requirements"},
+--     "order": 1,
+--     "completed": false,
+--     "completed_at": null
+--   },
+--   {
+--     "id": "step-2", 
+--     "description": "Design solution",
+--     "action": "design",
+--     "parameters": {"type": "technical"},
+--     "order": 2,
+--     "completed": true,
+--     "completed_at": "2024-01-15T10:30:00Z"
+--   }
+-- ]
+
+-- Example JSONB structure for context field:
+-- {
+--   "task_title": "Implement user authentication",
+--   "task_description": "Add JWT-based authentication system",
+--   "task_priority": "HIGH",
+--   "estimated_hours": 8.0,
+--   "requirements": ["security", "scalability"],
+--   "constraints": ["existing_db_schema", "api_compatibility"]
+-- }


### PR DESCRIPTION
**Mô tả**: Tạo repository để persist plan data

**Steps**:

1. Tạo `internal/repository/plan.go`:
   - Interface `PlanRepository` với methods:
     - `Create(plan *Plan) error`
     - `GetByID(id string) (*Plan, error)`
     - `GetByTaskID(taskID string) (*Plan, error)`
     - `Update(plan *Plan) error`
     - `Delete(id string) error`
     - `ListByStatus(status PlanStatus) ([]*Plan, error)`

2. Implement PostgreSQL repository:
   - `internal/repository/postgres/plan_repository.go`
   - Handle JSONB fields với GORM
   - Implement proper indexing
   - Add transaction support

3. Tạo database migration:
   - `migrations/000009_add_plan_tables.up.sql`
   - `migrations/000009_add_plan_tables.down.sql`
   - Include indexes cho performance

4. Implement plan versioning:
   - Track plan revisions
   - Compare plan versions
   - Rollback to previous versions

**Acceptance Criteria**:
- Plan CRUD operations hoạt động
- JSONB fields được handle đúng
- Performance optimization với indexes
- Versioning support implemented