### PR TITLE
Execute Plan: Remove unused logics - TaskRepository (vibe-kanban)

### DIFF
--- a/internal/repository/postgres/task_repository.go
+++ b/internal/repository/postgres/task_repository.go
@@ -732,19 +732,7 @@ func (r *taskRepository) GetAuditLogs(ctx context.Context, taskID uuid.UUID, lim
 	return logPtrs, nil
 }
 
-// CreateAuditLog creates a new audit log entry
-func (r *taskRepository) CreateAuditLog(ctx context.Context, auditLog *entity.TaskAuditLog) error {
-	if auditLog.ID == uuid.Nil {
-		auditLog.ID = uuid.New()
-	}
 
-	result := r.db.WithContext(ctx).Create(auditLog)
-	if result.Error != nil {
-		return fmt.Errorf("failed to create audit log: %w", result.Error)
-	}
-
-	return nil
-}
 
 // GetTaskStatistics retrieves comprehensive task statistics
 func (r *taskRepository) GetTaskStatistics(ctx context.Context, projectID uuid.UUID) (*entity.TaskStatistics, error) {
@@ -904,46 +892,7 @@ func (r *taskRepository) DeleteComment(ctx context.Context, commentID uuid.UUID)
 	return nil
 }
 
-// AddAttachment adds a file attachment to a task
-func (r *taskRepository) AddAttachment(ctx context.Context, attachment *entity.TaskAttachment) error {
-	if attachment.ID == uuid.Nil {
-		attachment.ID = uuid.New()
-	}
 
-	result := r.db.WithContext(ctx).Create(attachment)
-	if result.Error != nil {
-		return fmt.Errorf("failed to add attachment: %w", result.Error)
-	}
-
-	return nil
-}
-
-// GetAttachments retrieves attachments for a task
-func (r *taskRepository) GetAttachments(ctx context.Context, taskID uuid.UUID) ([]*entity.TaskAttachment, error) {
-	var attachments []entity.TaskAttachment
-
-	result := r.db.WithContext(ctx).Where("task_id = ?", taskID).Order("created_at ASC").Find(&attachments)
-	if result.Error != nil {
-		return nil, fmt.Errorf("failed to get attachments: %w", result.Error)
-	}
-
-	attachmentPtrs := make([]*entity.TaskAttachment, len(attachments))
-	for i := range attachments {
-		attachmentPtrs[i] = &attachments[i]
-	}
-
-	return attachmentPtrs, nil
-}
-
-// DeleteAttachment deletes a file attachment
-func (r *taskRepository) DeleteAttachment(ctx context.Context, attachmentID uuid.UUID) error {
-	result := r.db.WithContext(ctx).Delete(&entity.TaskAttachment{}, "id = ?", attachmentID)
-	if result.Error != nil {
-		return fmt.Errorf("failed to delete attachment: %w", result.Error)
-	}
-
-	return nil
-}
 
 // ExportTasks exports tasks in the specified format
 func (r *taskRepository) ExportTasks(ctx context.Context, filters entity.TaskFilters, format entity.TaskExportFormat) ([]byte, error) {

--- a/internal/repository/task.go
+++ b/internal/repository/task.go
@@ -53,7 +53,6 @@ type TaskRepository interface {
 
 	// Audit trail
 	GetAuditLogs(ctx context.Context, taskID uuid.UUID, limit *int) ([]*entity.TaskAuditLog, error)
-	CreateAuditLog(ctx context.Context, auditLog *entity.TaskAuditLog) error
 
 	// Statistics and analytics
 	GetStatusHistory(ctx context.Context, taskID uuid.UUID) ([]*entity.TaskStatusHistory, error)
@@ -72,10 +71,7 @@ type TaskRepository interface {
 	UpdateComment(ctx context.Context, comment *entity.TaskComment) error
 	DeleteComment(ctx context.Context, commentID uuid.UUID) error
 
-	// Attachments
-	AddAttachment(ctx context.Context, attachment *entity.TaskAttachment) error
-	GetAttachments(ctx context.Context, taskID uuid.UUID) ([]*entity.TaskAttachment, error)
-	DeleteAttachment(ctx context.Context, attachmentID uuid.UUID) error
+
 
 	// Export functionality
 	ExportTasks(ctx context.Context, filters entity.TaskFilters, format entity.TaskExportFormat) ([]byte, error)

--- a/internal/repository/task_repository_mock.go
+++ b/internal/repository/task_repository_mock.go
@@ -39,52 +39,6 @@ func (_m *TaskRepositoryMock) EXPECT() *TaskRepositoryMock_Expecter {
 	return &TaskRepositoryMock_Expecter{mock: &_m.Mock}
 }
 
-// AddAttachment provides a mock function for the type TaskRepositoryMock
-func (_mock *TaskRepositoryMock) AddAttachment(ctx context.Context, attachment *entity.TaskAttachment) error {
-	ret := _mock.Called(ctx, attachment)
-
-	if len(ret) == 0 {
-		panic("no return value specified for AddAttachment")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, *entity.TaskAttachment) error); ok {
-		r0 = returnFunc(ctx, attachment)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// TaskRepositoryMock_AddAttachment_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AddAttachment'
-type TaskRepositoryMock_AddAttachment_Call struct {
-	*mock.Call
-}
-
-// AddAttachment is a helper method to define mock.On call
-//   - ctx
-//   - attachment
-func (_e *TaskRepositoryMock_Expecter) AddAttachment(ctx interface{}, attachment interface{}) *TaskRepositoryMock_AddAttachment_Call {
-	return &TaskRepositoryMock_AddAttachment_Call{Call: _e.mock.On("AddAttachment", ctx, attachment)}
-}
-
-func (_c *TaskRepositoryMock_AddAttachment_Call) Run(run func(ctx context.Context, attachment *entity.TaskAttachment)) *TaskRepositoryMock_AddAttachment_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*entity.TaskAttachment))
-	})
-	return _c
-}
-
-func (_c *TaskRepositoryMock_AddAttachment_Call) Return(err error) *TaskRepositoryMock_AddAttachment_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *TaskRepositoryMock_AddAttachment_Call) RunAndReturn(run func(ctx context.Context, attachment *entity.TaskAttachment) error) *TaskRepositoryMock_AddAttachment_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // AddComment provides a mock function for the type TaskRepositoryMock
 func (_mock *TaskRepositoryMock) AddComment(ctx context.Context, comment *entity.TaskComment) error {
 	ret := _mock.Called(ctx, comment)
@@ -562,52 +516,6 @@ func (_c *TaskRepositoryMock_Create_Call) RunAndReturn(run func(ctx context.Cont
 	return _c
 }
 
-// CreateAuditLog provides a mock function for the type TaskRepositoryMock
-func (_mock *TaskRepositoryMock) CreateAuditLog(ctx context.Context, auditLog *entity.TaskAuditLog) error {
-	ret := _mock.Called(ctx, auditLog)
-
-	if len(ret) == 0 {
-		panic("no return value specified for CreateAuditLog")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, *entity.TaskAuditLog) error); ok {
-		r0 = returnFunc(ctx, auditLog)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// TaskRepositoryMock_CreateAuditLog_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateAuditLog'
-type TaskRepositoryMock_CreateAuditLog_Call struct {
-	*mock.Call
-}
-
-// CreateAuditLog is a helper method to define mock.On call
-//   - ctx
-//   - auditLog
-func (_e *TaskRepositoryMock_Expecter) CreateAuditLog(ctx interface{}, auditLog interface{}) *TaskRepositoryMock_CreateAuditLog_Call {
-	return &TaskRepositoryMock_CreateAuditLog_Call{Call: _e.mock.On("CreateAuditLog", ctx, auditLog)}
-}
-
-func (_c *TaskRepositoryMock_CreateAuditLog_Call) Run(run func(ctx context.Context, auditLog *entity.TaskAuditLog)) *TaskRepositoryMock_CreateAuditLog_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*entity.TaskAuditLog))
-	})
-	return _c
-}
-
-func (_c *TaskRepositoryMock_CreateAuditLog_Call) Return(err error) *TaskRepositoryMock_CreateAuditLog_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *TaskRepositoryMock_CreateAuditLog_Call) RunAndReturn(run func(ctx context.Context, auditLog *entity.TaskAuditLog) error) *TaskRepositoryMock_CreateAuditLog_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // CreateTaskFromTemplate provides a mock function for the type TaskRepositoryMock
 func (_mock *TaskRepositoryMock) CreateTaskFromTemplate(ctx context.Context, templateID uuid.UUID, projectID uuid.UUID, createdBy string) (*entity.Task, error) {
 	ret := _mock.Called(ctx, templateID, projectID, createdBy)
@@ -755,52 +663,6 @@ func (_c *TaskRepositoryMock_Delete_Call) Return(err error) *TaskRepositoryMock_
 }
 
 func (_c *TaskRepositoryMock_Delete_Call) RunAndReturn(run func(ctx context.Context, id uuid.UUID) error) *TaskRepositoryMock_Delete_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// DeleteAttachment provides a mock function for the type TaskRepositoryMock
-func (_mock *TaskRepositoryMock) DeleteAttachment(ctx context.Context, attachmentID uuid.UUID) error {
-	ret := _mock.Called(ctx, attachmentID)
-
-	if len(ret) == 0 {
-		panic("no return value specified for DeleteAttachment")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, uuid.UUID) error); ok {
-		r0 = returnFunc(ctx, attachmentID)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// TaskRepositoryMock_DeleteAttachment_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteAttachment'
-type TaskRepositoryMock_DeleteAttachment_Call struct {
-	*mock.Call
-}
-
-// DeleteAttachment is a helper method to define mock.On call
-//   - ctx
-//   - attachmentID
-func (_e *TaskRepositoryMock_Expecter) DeleteAttachment(ctx interface{}, attachmentID interface{}) *TaskRepositoryMock_DeleteAttachment_Call {
-	return &TaskRepositoryMock_DeleteAttachment_Call{Call: _e.mock.On("DeleteAttachment", ctx, attachmentID)}
-}
-
-func (_c *TaskRepositoryMock_DeleteAttachment_Call) Run(run func(ctx context.Context, attachmentID uuid.UUID)) *TaskRepositoryMock_DeleteAttachment_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(uuid.UUID))
-	})
-	return _c
-}
-
-func (_c *TaskRepositoryMock_DeleteAttachment_Call) Return(err error) *TaskRepositoryMock_DeleteAttachment_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *TaskRepositoryMock_DeleteAttachment_Call) RunAndReturn(run func(ctx context.Context, attachmentID uuid.UUID) error) *TaskRepositoryMock_DeleteAttachment_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1008,63 +870,6 @@ func (_c *TaskRepositoryMock_GetArchivedTasks_Call) Return(tasks []*entity.Task,
 }
 
 func (_c *TaskRepositoryMock_GetArchivedTasks_Call) RunAndReturn(run func(ctx context.Context, projectID *uuid.UUID) ([]*entity.Task, error)) *TaskRepositoryMock_GetArchivedTasks_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetAttachments provides a mock function for the type TaskRepositoryMock
-func (_mock *TaskRepositoryMock) GetAttachments(ctx context.Context, taskID uuid.UUID) ([]*entity.TaskAttachment, error) {
-	ret := _mock.Called(ctx, taskID)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetAttachments")
-	}
-
-	var r0 []*entity.TaskAttachment
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, uuid.UUID) ([]*entity.TaskAttachment, error)); ok {
-		return returnFunc(ctx, taskID)
-	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, uuid.UUID) []*entity.TaskAttachment); ok {
-		r0 = returnFunc(ctx, taskID)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]*entity.TaskAttachment)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, uuid.UUID) error); ok {
-		r1 = returnFunc(ctx, taskID)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// TaskRepositoryMock_GetAttachments_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAttachments'
-type TaskRepositoryMock_GetAttachments_Call struct {
-	*mock.Call
-}
-
-// GetAttachments is a helper method to define mock.On call
-//   - ctx
-//   - taskID
-func (_e *TaskRepositoryMock_Expecter) GetAttachments(ctx interface{}, taskID interface{}) *TaskRepositoryMock_GetAttachments_Call {
-	return &TaskRepositoryMock_GetAttachments_Call{Call: _e.mock.On("GetAttachments", ctx, taskID)}
-}
-
-func (_c *TaskRepositoryMock_GetAttachments_Call) Run(run func(ctx context.Context, taskID uuid.UUID)) *TaskRepositoryMock_GetAttachments_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(uuid.UUID))
-	})
-	return _c
-}
-
-func (_c *TaskRepositoryMock_GetAttachments_Call) Return(taskAttachments []*entity.TaskAttachment, err error) *TaskRepositoryMock_GetAttachments_Call {
-	_c.Call.Return(taskAttachments, err)
-	return _c
-}
-
-func (_c *TaskRepositoryMock_GetAttachments_Call) RunAndReturn(run func(ctx context.Context, taskID uuid.UUID) ([]*entity.TaskAttachment, error)) *TaskRepositoryMock_GetAttachments_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/usecase/task_usecase_mock.go
+++ b/internal/usecase/task_usecase_mock.go
@@ -1532,6 +1532,63 @@ func (_c *TaskUsecaseMock_GetParentTask_Call) RunAndReturn(run func(ctx context.
 	return _c
 }
 
+// GetPullRequest provides a mock function for the type TaskUsecaseMock
+func (_mock *TaskUsecaseMock) GetPullRequest(ctx context.Context, taskID uuid.UUID) (*entity.PullRequest, error) {
+	ret := _mock.Called(ctx, taskID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetPullRequest")
+	}
+
+	var r0 *entity.PullRequest
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uuid.UUID) (*entity.PullRequest, error)); ok {
+		return returnFunc(ctx, taskID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uuid.UUID) *entity.PullRequest); ok {
+		r0 = returnFunc(ctx, taskID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*entity.PullRequest)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, uuid.UUID) error); ok {
+		r1 = returnFunc(ctx, taskID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// TaskUsecaseMock_GetPullRequest_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetPullRequest'
+type TaskUsecaseMock_GetPullRequest_Call struct {
+	*mock.Call
+}
+
+// GetPullRequest is a helper method to define mock.On call
+//   - ctx
+//   - taskID
+func (_e *TaskUsecaseMock_Expecter) GetPullRequest(ctx interface{}, taskID interface{}) *TaskUsecaseMock_GetPullRequest_Call {
+	return &TaskUsecaseMock_GetPullRequest_Call{Call: _e.mock.On("GetPullRequest", ctx, taskID)}
+}
+
+func (_c *TaskUsecaseMock_GetPullRequest_Call) Run(run func(ctx context.Context, taskID uuid.UUID)) *TaskUsecaseMock_GetPullRequest_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(uuid.UUID))
+	})
+	return _c
+}
+
+func (_c *TaskUsecaseMock_GetPullRequest_Call) Return(pullRequest *entity.PullRequest, err error) *TaskUsecaseMock_GetPullRequest_Call {
+	_c.Call.Return(pullRequest, err)
+	return _c
+}
+
+func (_c *TaskUsecaseMock_GetPullRequest_Call) RunAndReturn(run func(ctx context.Context, taskID uuid.UUID) (*entity.PullRequest, error)) *TaskUsecaseMock_GetPullRequest_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetStatusAnalytics provides a mock function for the type TaskUsecaseMock
 func (_mock *TaskUsecaseMock) GetStatusAnalytics(ctx context.Context, projectID uuid.UUID) (*entity.TaskStatusAnalytics, error) {
 	ret := _mock.Called(ctx, projectID)

--- a/internal/websocket/server.go
+++ b/internal/websocket/server.go
@@ -78,13 +78,13 @@ func NewServer(appConfig *config.CentrifugeRedisBrokerConfig) (*Server, error) {
 				// private channel require user_id to be the same as the client.UserID()
 				channelParts := strings.Split(e.Channel, ":")
 				if len(channelParts) < 2 {
-					log.Printf("[%d] error adding subscription: invalid private channel format", e.Channel)
+					log.Printf("[%s] error adding subscription: invalid private channel format", e.Channel)
 					cb(centrifuge.SubscribeReply{}, centrifuge.ErrorBadRequest)
 					return
 				}
 				channelUserId := channelParts[1]
 				if client.UserID() != channelUserId {
-					log.Printf("[%d] error adding subscription: permission denied for private channel", e.Channel)
+					log.Printf("[%s] error adding subscription: permission denied for private channel", e.Channel)
 					cb(centrifuge.SubscribeReply{}, centrifuge.ErrorPermissionDenied)
 					return
 				}


### PR DESCRIPTION
# Unused TaskRepository Methods Removal Plan

## Analysis Summary
I've analyzed the TaskRepository interface and its usage across the codebase. Many methods are defined but not actually used in the application.

## Unused Methods to Remove

**File Attachment Methods** (Lines 75-78):
- `AddAttachment(ctx context.Context, attachment *entity.TaskAttachment) error`
- `GetAttachments(ctx context.Context, taskID uuid.UUID) ([]*entity.TaskAttachment, error)`
- `DeleteAttachment(ctx context.Context, attachmentID uuid.UUID) error`

**Audit Trail Method** (Line 56):
- `CreateAuditLog(ctx context.Context, auditLog *entity.TaskAuditLog) error`

All these methods are:
1. Not used in any usecase layer
2. Not exposed in any HTTP handler 
3. Have no test coverage
4. Only implemented with placeholder or basic functionality

## Files to Modify

1. **Interface**: `/internal/repository/task.go` (lines 75-78, 56)
2. **Implementation**: `/internal/repository/postgres/task_repository.go` (lines 735-746, 907-946)
3. **Mock**: `/internal/repository/task_repository_mock.go` (regenerate after interface changes)
4. **Tests**: Remove any related test cases (none found currently)

## Steps
1. Remove unused methods from TaskRepository interface
2. Remove implementations from postgres/task_repository.go
3. Regenerate mocks using `make mocks-regen`
4. Run tests to ensure build integrity
5. Run lint checks

This will clean up ~150 lines of unused code while maintaining all functional features.