### PR TITLE
Liệt kê các api endpoint (vibe-kanban)

### DIFF
--- a/docs/api-endpoints.csv
+++ b/docs/api-endpoints.csv
@@ -1,7 +1,5 @@
 method,endpoint,in-use
-GET,/swagger/*any,false
 GET,/api/v1/health,false
-GET,/ws/connect,true
 GET,/api/v1/websocket/connections,false
 GET,/api/v1/websocket/metrics,false
 POST,/api/v1/websocket/broadcast,false
@@ -54,3 +52,13 @@ GET,/api/v1/executions/:id,true
 PUT,/api/v1/executions/:id,true
 DELETE,/api/v1/executions/:id,true
 GET,/api/v1/executions/:id/logs,true
+GET,/api/v1/executions/:id/logs/stats,true
+GET,/api/v1/pull-requests,false
+GET,/api/v1/pull-requests/:id,false
+POST,/api/v1/pull-requests,false
+PUT,/api/v1/pull-requests/:id,false
+DELETE,/api/v1/pull-requests/:id,false
+POST,/api/v1/pull-requests/:id/sync,false
+POST,/api/v1/pull-requests/:id/merge,false
+POST,/api/v1/pull-requests/:id/close,false
+POST,/api/v1/pull-requests/:id/reopen,false


### PR DESCRIPTION
- Liệt kê các API endpoint mà frontend đang sử dụng để connect đến backend.
- Liệt kê các API endpoint mà backend đang có 
- Thống kê các endpoint backend có mà frontend đang không dùng.
- Kết quả ghi vào file `docs/api-endpoints.csv` theo định dạng
  + method: POST/GET/DELETE....
  + endpoint: ví dụ /api/v1/tasks
  + in-use: true/false (true là đang được frontend sử dụng)
 