### PR TITLE
Improve MCP server stability (P0 critical fixes)

### DIFF
--- a/internal/handler/health.go
+++ b/internal/handler/health.go
@@ -21,9 +21,14 @@ type DatabaseHealth struct {
 }
 
 func SetupHealthRoutes(router *gin.Engine, db *database.GormDB) {
+	handler := healthCheck(db)
+
+	// Root health endpoint for MCP server and load balancers
+	router.GET("/health", handler)
+
 	v1 := router.Group("/api/v1")
 	{
-		v1.GET("/health", healthCheck(db))
+		v1.GET("/health", handler)
 	}
 }
 

--- a/internal/handler/middleware.go
+++ b/internal/handler/middleware.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/auto-devs/auto-devs/internal/handler/dto"
@@ -134,29 +136,98 @@ func getValidationErrorMessage(fe validator.FieldError) string {
 	}
 }
 
-// RateLimitMiddleware implements basic rate limiting
+// RateLimitMiddleware implements per-client rate limiting (100 requests/min per client)
 func RateLimitMiddleware() gin.HandlerFunc {
-	// Create a rate limiter that allows 100 requests per minute
-	limiter := rate.NewLimiter(rate.Every(time.Minute/100), 100)
+	const (
+		requestsPerMinute = 100
+		cleanupInterval   = 5 * time.Minute
+		idleTimeout       = 10 * time.Minute
+	)
+
+	var (
+		clientLimiters sync.Map
+		cleanupOnce    sync.Once
+	)
+
+	startCleanup := func() {
+		cleanupOnce.Do(func() {
+			go func() {
+				ticker := time.NewTicker(cleanupInterval)
+				defer ticker.Stop()
+
+				for range ticker.C {
+					now := time.Now()
+					clientLimiters.Range(func(key, value any) bool {
+						entry := value.(*clientLimiterEntry)
+						if now.Sub(entry.lastSeen) > idleTimeout {
+							clientLimiters.Delete(key)
+						}
+						return true
+					})
+				}
+			}()
+		})
+	}
+
+	getClientLimiter := func(clientKey string) *rate.Limiter {
+		startCleanup()
+
+		if value, ok := clientLimiters.Load(clientKey); ok {
+			entry := value.(*clientLimiterEntry)
+			entry.lastSeen = time.Now()
+			return entry.limiter
+		}
+
+		limiter := rate.NewLimiter(rate.Every(time.Minute/requestsPerMinute), requestsPerMinute)
+		entry := &clientLimiterEntry{
+			limiter:  limiter,
+			lastSeen: time.Now(),
+		}
+		actual, _ := clientLimiters.LoadOrStore(clientKey, entry)
+		return actual.(*clientLimiterEntry).limiter
+	}
+
+	getClientKey := func(c *gin.Context) string {
+		authHeader := c.GetHeader("Authorization")
+		if authHeader != "" {
+			return "auth:" + authHeader
+		}
+		return "ip:" + c.ClientIP()
+	}
+
+	isRateLimitExempt := func(path string) bool {
+		return path == "/ws" ||
+			path == "/health" ||
+			strings.HasPrefix(path, "/health/") ||
+			path == "/api/v1/health"
+	}
 
 	return func(c *gin.Context) {
-		// Skip rate limiting for WebSocket endpoints
-		if c.Request.URL.Path == "/ws" {
+		if isRateLimitExempt(c.Request.URL.Path) {
 			c.Next()
 			return
 		}
 
+		clientKey := getClientKey(c)
+		limiter := getClientLimiter(clientKey)
+
 		if !limiter.Allow() {
 			c.JSON(http.StatusTooManyRequests, dto.ErrorResponse{
 				Error:   "Rate limit exceeded",
-				Message: "Too many requests, please try again later",
+				Message: "Too many requests from this client, please try again later",
 				Code:    http.StatusTooManyRequests,
 			})
 			c.Abort()
 			return
 		}
+
 		c.Next()
 	}
+}
+
+type clientLimiterEntry struct {
+	limiter  *rate.Limiter
+	lastSeen time.Time
 }
 
 // SecurityHeadersMiddleware adds security headers

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -11,6 +11,7 @@ import { TOOLS, getToolByName } from './tools/index.js';
 import { config } from './config.js';
 import { AppError } from './errors/app-error.js';
 import { logger } from './utils/logger.js';
+import { checkBackendHealth } from './utils/health-check.js';
 
 const server = new Server(
   {
@@ -102,6 +103,14 @@ async function main() {
   console.error('[MCP] Starting Auto-Devs MCP Server');
   console.error(`[MCP] API URL: ${config.apiUrl}`);
   console.error(`[MCP] Debug mode: ${config.debug}`);
+
+  try {
+    await checkBackendHealth();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`[MCP] Backend health check failed: ${message}`);
+    process.exit(1);
+  }
 
   const transport = new StdioServerTransport();
   await server.connect(transport);

--- a/mcp-server/src/tools/execution-tools.ts
+++ b/mcp-server/src/tools/execution-tools.ts
@@ -1,7 +1,26 @@
 import { Tool } from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod';
 import AutoDevsClient from '../client/autodevs-client.js';
+import { validateInput } from '../utils/validate-input.js';
 
 const client = new AutoDevsClient();
+
+const executionListSchema = z.object({
+  taskId: z.string().min(1, 'Task ID is required'),
+  page: z.coerce.number().int().positive().optional().default(1),
+  pageSize: z.coerce.number().int().positive().max(100).optional().default(10),
+  status: z.string().optional(),
+});
+
+const executionIdSchema = z.object({
+  id: z.string().min(1, 'Execution ID is required'),
+});
+
+const executionCreateSchema = z.object({
+  taskId: z.string().min(1, 'Task ID is required'),
+  scheduled: z.boolean().optional(),
+  scheduledAt: z.string().optional(),
+});
 
 export const executionListTool: Tool = {
   name: 'execution:list',
@@ -31,10 +50,7 @@ export const executionListTool: Tool = {
 };
 
 export async function executeExecutionList(input: Record<string, unknown>): Promise<string> {
-  const taskId = input.taskId as string;
-  const page = (input.page as number) || 1;
-  const pageSize = (input.pageSize as number) || 10;
-  const status = input.status as string | undefined;
+  const { taskId, page, pageSize, status } = validateInput(executionListSchema, input);
 
   const result = await client.listExecutions(taskId, { page, pageSize, status });
   return JSON.stringify(result, null, 2);
@@ -56,7 +72,7 @@ export const executionGetTool: Tool = {
 };
 
 export async function executeExecutionGet(input: Record<string, unknown>): Promise<string> {
-  const id = input.id as string;
+  const { id } = validateInput(executionIdSchema, input);
   const result = await client.getExecution(id);
   return JSON.stringify(result, null, 2);
 }
@@ -85,15 +101,16 @@ export const executionCreateTool: Tool = {
 };
 
 export async function executeExecutionCreate(input: Record<string, unknown>): Promise<string> {
-  const taskId = input.taskId as string;
-  const data: any = {};
-  if (input.scheduled) {
+  const parsed = validateInput(executionCreateSchema, input);
+  const data: Record<string, unknown> = {};
+
+  if (parsed.scheduled) {
     data.scheduled = true;
-    if (input.scheduledAt) {
-      data.scheduledAt = input.scheduledAt;
+    if (parsed.scheduledAt) {
+      data.scheduledAt = parsed.scheduledAt;
     }
   }
 
-  const result = await client.createExecution(taskId, data);
+  const result = await client.createExecution(parsed.taskId, data);
   return JSON.stringify(result, null, 2);
 }

--- a/mcp-server/src/tools/project-tools.ts
+++ b/mcp-server/src/tools/project-tools.ts
@@ -1,8 +1,18 @@
 import { Tool } from '@modelcontextprotocol/sdk/types.js';
-import AutoDevsClient from '../client/autodevs-client.js';
 import { z } from 'zod';
+import AutoDevsClient from '../client/autodevs-client.js';
+import { validateInput } from '../utils/validate-input.js';
 
 const client = new AutoDevsClient();
+
+const projectListSchema = z.object({
+  page: z.coerce.number().int().positive().optional().default(1),
+  pageSize: z.coerce.number().int().positive().max(100).optional().default(10),
+});
+
+const projectGetSchema = z.object({
+  id: z.string().min(1, 'Project ID is required'),
+});
 
 export const projectListTool: Tool = {
   name: 'project:list',
@@ -23,8 +33,7 @@ export const projectListTool: Tool = {
 };
 
 export async function executeProjectList(input: Record<string, unknown>): Promise<string> {
-  const page = (input.page as number) || 1;
-  const pageSize = (input.pageSize as number) || 10;
+  const { page, pageSize } = validateInput(projectListSchema, input);
 
   const result = await client.listProjects(page, pageSize);
   return JSON.stringify(result, null, 2);
@@ -46,7 +55,7 @@ export const projectGetTool: Tool = {
 };
 
 export async function executeProjectGet(input: Record<string, unknown>): Promise<string> {
-  const id = input.id as string;
+  const { id } = validateInput(projectGetSchema, input);
   const result = await client.getProject(id);
   return JSON.stringify(result, null, 2);
 }

--- a/mcp-server/src/tools/task-tools.ts
+++ b/mcp-server/src/tools/task-tools.ts
@@ -1,7 +1,54 @@
 import { Tool } from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod';
 import AutoDevsClient from '../client/autodevs-client.js';
+import { validateInput } from '../utils/validate-input.js';
 
 const client = new AutoDevsClient();
+
+const taskListSchema = z.object({
+  projectId: z.string().min(1, 'Project ID is required'),
+  page: z.coerce.number().int().positive().optional().default(1),
+  pageSize: z.coerce.number().int().positive().max(100).optional().default(10),
+  status: z.string().optional(),
+  priority: z.string().optional(),
+});
+
+const taskCreateSchema = z.object({
+  projectId: z.string().min(1, 'Project ID is required'),
+  title: z.string().min(1, 'Title is required'),
+  description: z.string().optional(),
+  priority: z.string().optional(),
+  kanban_task_id: z.string().optional(),
+});
+
+const taskUpdateStatusSchema = z.object({
+  taskId: z.string().min(1, 'Task ID is required'),
+  status: z.string().min(1, 'Status is required'),
+});
+
+const taskIdSchema = z.object({
+  id: z.string().min(1, 'Task ID is required'),
+});
+
+const taskStartPlanningSchema = z.object({
+  taskId: z.string().min(1, 'Task ID is required'),
+  branchName: z.string().min(1, 'Branch name is required'),
+  aiType: z.string().min(1, 'AI type is required'),
+  useRemoteBranch: z.boolean().optional(),
+  autoImplement: z.boolean().optional(),
+});
+
+const taskApprovePlanSchema = z.object({
+  taskId: z.string().min(1, 'Task ID is required'),
+  aiType: z.string().min(1, 'AI type is required'),
+});
+
+const taskStartImplementingDirectSchema = z.object({
+  taskId: z.string().min(1, 'Task ID is required'),
+  branchName: z.string().min(1, 'Branch name is required'),
+  aiType: z.string().min(1, 'AI type is required'),
+  useRemoteBranch: z.boolean().optional(),
+});
 
 export const taskListTool: Tool = {
   name: 'task:list',
@@ -35,15 +82,9 @@ export const taskListTool: Tool = {
 };
 
 export async function executeTaskList(input: Record<string, unknown>): Promise<string> {
-  const projectId = input.projectId as string;
-  const page = (input.page as number) || 1;
-  const pageSize = (input.pageSize as number) || 10;
-  const filters = {
-    status: input.status,
-    priority: input.priority,
-  };
+  const { projectId, page, pageSize, status, priority } = validateInput(taskListSchema, input);
 
-  const result = await client.listTasks(projectId, { page, pageSize, ...filters });
+  const result = await client.listTasks(projectId, { page, pageSize, status, priority });
   return JSON.stringify(result, null, 2);
 }
 
@@ -79,15 +120,20 @@ export const taskCreateTool: Tool = {
 };
 
 export async function executeTaskCreate(input: Record<string, unknown>): Promise<string> {
-  const projectId = input.projectId as string;
-  // Backend expects snake_case field names (see SKILL.md "MCP Bug Fixed")
+  const parsed = validateInput(taskCreateSchema, input);
+  const { projectId, ...taskFields } = parsed;
+
   const taskData: Record<string, unknown> = {
-    title: input.title as string,
-    description: input.description as string,
-    priority: input.priority as string,
+    title: taskFields.title,
   };
-  if (input.kanban_task_id) {
-    taskData.kanban_task_id = input.kanban_task_id as string;
+  if (taskFields.description !== undefined) {
+    taskData.description = taskFields.description;
+  }
+  if (taskFields.priority !== undefined) {
+    taskData.priority = taskFields.priority;
+  }
+  if (taskFields.kanban_task_id !== undefined) {
+    taskData.kanban_task_id = taskFields.kanban_task_id;
   }
 
   const result = await client.createTask(projectId, taskData);
@@ -114,8 +160,7 @@ export const taskUpdateStatusTool: Tool = {
 };
 
 export async function executeTaskUpdateStatus(input: Record<string, unknown>): Promise<string> {
-  const taskId = input.taskId as string;
-  const status = input.status as string;
+  const { taskId, status } = validateInput(taskUpdateStatusSchema, input);
 
   const result = await client.updateTaskStatus(taskId, status);
   return JSON.stringify(result, null, 2);
@@ -137,7 +182,7 @@ export const taskGetTool: Tool = {
 };
 
 export async function executeTaskGet(input: Record<string, unknown>): Promise<string> {
-  const id = input.id as string;
+  const { id } = validateInput(taskIdSchema, input);
   const result = await client.getTask(id);
   return JSON.stringify(result, null, 2);
 }
@@ -158,7 +203,7 @@ export const taskDeleteTool: Tool = {
 };
 
 export async function executeTaskDelete(input: Record<string, unknown>): Promise<string> {
-  const id = input.id as string;
+  const { id } = validateInput(taskIdSchema, input);
   await client.deleteTask(id);
   return JSON.stringify({ success: true, message: `Task ${id} deleted` });
 }
@@ -186,11 +231,12 @@ export const taskStartPlanningTool: Tool = {
 };
 
 export async function executeTaskStartPlanning(input: Record<string, unknown>): Promise<string> {
-  const result = await client.startPlanning(input.taskId as string, {
-    branchName: input.branchName as string,
-    aiType: input.aiType as string,
-    useRemoteBranch: input.useRemoteBranch as boolean | undefined,
-    autoImplement: input.autoImplement as boolean | undefined,
+  const parsed = validateInput(taskStartPlanningSchema, input);
+  const result = await client.startPlanning(parsed.taskId, {
+    branchName: parsed.branchName,
+    aiType: parsed.aiType,
+    useRemoteBranch: parsed.useRemoteBranch,
+    autoImplement: parsed.autoImplement,
   });
   return JSON.stringify(result, null, 2);
 }
@@ -209,8 +255,9 @@ export const taskApprovePlanTool: Tool = {
 };
 
 export async function executeTaskApprovePlan(input: Record<string, unknown>): Promise<string> {
-  const result = await client.approvePlan(input.taskId as string, {
-    aiType: input.aiType as string,
+  const parsed = validateInput(taskApprovePlanSchema, input);
+  const result = await client.approvePlan(parsed.taskId, {
+    aiType: parsed.aiType,
   });
   return JSON.stringify(result, null, 2);
 }
@@ -236,10 +283,11 @@ export const taskStartImplementingDirectTool: Tool = {
 export async function executeTaskStartImplementingDirect(
   input: Record<string, unknown>
 ): Promise<string> {
-  const result = await client.startImplementingDirect(input.taskId as string, {
-    branchName: input.branchName as string,
-    aiType: input.aiType as string,
-    useRemoteBranch: input.useRemoteBranch as boolean | undefined,
+  const parsed = validateInput(taskStartImplementingDirectSchema, input);
+  const result = await client.startImplementingDirect(parsed.taskId, {
+    branchName: parsed.branchName,
+    aiType: parsed.aiType,
+    useRemoteBranch: parsed.useRemoteBranch,
   });
   return JSON.stringify(result, null, 2);
 }

--- a/mcp-server/src/tools/worktree-tools.ts
+++ b/mcp-server/src/tools/worktree-tools.ts
@@ -1,7 +1,13 @@
 import { Tool } from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod';
 import AutoDevsClient from '../client/autodevs-client.js';
+import { validateInput } from '../utils/validate-input.js';
 
 const client = new AutoDevsClient();
+
+const worktreeGetStatusSchema = z.object({
+  projectId: z.string().min(1, 'Project ID is required'),
+});
 
 export const worktreeGetStatusTool: Tool = {
   name: 'worktree:get-status',
@@ -19,7 +25,7 @@ export const worktreeGetStatusTool: Tool = {
 };
 
 export async function executeWorktreeGetStatus(input: Record<string, unknown>): Promise<string> {
-  const projectId = input.projectId as string;
+  const { projectId } = validateInput(worktreeGetStatusSchema, input);
 
   const result = await client.getWorktreeStatus(projectId);
   return JSON.stringify(result, null, 2);

--- a/mcp-server/src/utils/circuit-breaker.ts
+++ b/mcp-server/src/utils/circuit-breaker.ts
@@ -1,0 +1,82 @@
+export enum CircuitState {
+  CLOSED = 'CLOSED',
+  OPEN = 'OPEN',
+  HALF_OPEN = 'HALF_OPEN',
+}
+
+export interface CircuitBreakerOptions {
+  failureThreshold?: number;
+  resetTimeoutMs?: number;
+}
+
+export class CircuitBreaker {
+  private state: CircuitState = CircuitState.CLOSED;
+  private failureCount = 0;
+  private lastFailureTime = 0;
+  private halfOpenProbeInFlight = false;
+
+  private readonly failureThreshold: number;
+  private readonly resetTimeoutMs: number;
+
+  constructor(options: CircuitBreakerOptions = {}) {
+    this.failureThreshold = options.failureThreshold ?? 5;
+    this.resetTimeoutMs = options.resetTimeoutMs ?? 30_000;
+  }
+
+  getState(): CircuitState {
+    if (this.state === CircuitState.OPEN) {
+      if (Date.now() - this.lastFailureTime >= this.resetTimeoutMs) {
+        this.state = CircuitState.HALF_OPEN;
+        this.halfOpenProbeInFlight = false;
+      }
+    }
+    return this.state;
+  }
+
+  canExecute(): boolean {
+    const state = this.getState();
+
+    if (state === CircuitState.CLOSED) {
+      return true;
+    }
+
+    if (state === CircuitState.OPEN) {
+      return false;
+    }
+
+    // HALF_OPEN: allow a single probe request
+    if (!this.halfOpenProbeInFlight) {
+      this.halfOpenProbeInFlight = true;
+      return true;
+    }
+
+    return false;
+  }
+
+  recordSuccess(): void {
+    this.failureCount = 0;
+    this.state = CircuitState.CLOSED;
+    this.halfOpenProbeInFlight = false;
+  }
+
+  recordFailure(): void {
+    this.lastFailureTime = Date.now();
+    this.halfOpenProbeInFlight = false;
+
+    if (this.state === CircuitState.HALF_OPEN) {
+      this.state = CircuitState.OPEN;
+      return;
+    }
+
+    this.failureCount += 1;
+    if (this.failureCount >= this.failureThreshold) {
+      this.state = CircuitState.OPEN;
+    }
+  }
+}
+
+/** Shared circuit breaker for all backend API calls */
+export const backendCircuitBreaker = new CircuitBreaker({
+  failureThreshold: 5,
+  resetTimeoutMs: 30_000,
+});

--- a/mcp-server/src/utils/health-check.ts
+++ b/mcp-server/src/utils/health-check.ts
@@ -1,0 +1,58 @@
+import axios from 'axios';
+import { config } from '../config.js';
+import { sleep } from './retry.js';
+
+export interface HealthCheckResult {
+  status: string;
+  endpoint: string;
+}
+
+const HEALTH_PATHS = ['/health', '/api/v1/health'];
+const MAX_ATTEMPTS = 5;
+const RETRY_DELAY_MS = 1000;
+
+export async function checkBackendHealth(): Promise<HealthCheckResult> {
+  let lastError: Error | undefined;
+
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    for (const path of HEALTH_PATHS) {
+      const endpoint = `${config.apiUrl}${path}`;
+
+      try {
+        const response = await axios.get(endpoint, {
+          timeout: 5000,
+          headers: config.apiKey
+            ? { Authorization: `Bearer ${config.apiKey}` }
+            : undefined,
+          validateStatus: (status) => status === 200 || status === 503,
+        });
+
+        const status =
+          typeof response.data?.status === 'string'
+            ? response.data.status
+            : 'ok';
+
+        console.error(
+          `[MCP] Backend health check passed (${endpoint}, status=${status})`
+        );
+
+        return { status, endpoint };
+      } catch (error) {
+        lastError = error instanceof Error ? error : new Error(String(error));
+        console.error(
+          `[MCP] Health check attempt ${attempt}/${MAX_ATTEMPTS} failed for ${endpoint}: ${lastError.message}`
+        );
+      }
+    }
+
+    if (attempt < MAX_ATTEMPTS) {
+      await sleep(RETRY_DELAY_MS);
+    }
+  }
+
+  throw new Error(
+    `Backend API at ${config.apiUrl} is not reachable. ` +
+      `Ensure the Auto-Devs server is running and accessible. ` +
+      `Last error: ${lastError?.message ?? 'unknown'}`
+  );
+}

--- a/mcp-server/src/utils/retry.ts
+++ b/mcp-server/src/utils/retry.ts
@@ -1,5 +1,6 @@
-import { AppError } from '../errors/app-error.js';
+import { AppError, ErrorCode } from '../errors/app-error.js';
 import { config } from '../config.js';
+import { backendCircuitBreaker } from './circuit-breaker.js';
 
 export interface RetryOptions {
   maxRetries?: number;
@@ -17,38 +18,58 @@ export async function withRetry<T>(
   fn: () => Promise<T>,
   options: RetryOptions = {}
 ): Promise<T> {
+  if (!backendCircuitBreaker.canExecute()) {
+    const state = backendCircuitBreaker.getState();
+    throw new AppError(
+      ErrorCode.SERVICE_UNAVAILABLE,
+      `Backend API circuit breaker is ${state}. Failing fast to prevent request storm.`,
+      {
+        suggestion:
+          'Wait for the backend to recover. The circuit will retry automatically after 30 seconds.',
+        details: { circuitState: state },
+      }
+    );
+  }
+
   const opts = { ...DEFAULT_OPTIONS, ...options };
   let lastError: Error | undefined;
 
-  for (let attempt = 0; attempt < opts.maxRetries; attempt++) {
-    try {
-      return await fn();
-    } catch (error) {
-      lastError = error instanceof Error ? error : new Error(String(error));
+  try {
+    for (let attempt = 0; attempt < opts.maxRetries; attempt++) {
+      try {
+        const result = await fn();
+        backendCircuitBreaker.recordSuccess();
+        return result;
+      } catch (error) {
+        lastError = error instanceof Error ? error : new Error(String(error));
 
-      const isAppError = error instanceof AppError;
-      const isRetryable = isAppError && error.isRetryable();
+        const isAppError = error instanceof AppError;
+        const isRetryable = isAppError && error.isRetryable();
 
-      if (!isRetryable || attempt === opts.maxRetries - 1) {
-        throw error;
-      }
+        if (!isRetryable || attempt === opts.maxRetries - 1) {
+          throw error;
+        }
 
-      const delayMs = Math.min(
-        opts.initialDelayMs * Math.pow(2, attempt),
-        opts.maxDelayMs
-      );
-
-      if (config.debug) {
-        console.error(
-          `[RETRY] Attempt ${attempt + 1}/${opts.maxRetries} failed, retrying in ${delayMs}ms`
+        const delayMs = Math.min(
+          opts.initialDelayMs * Math.pow(2, attempt),
+          opts.maxDelayMs
         );
+
+        if (config.debug) {
+          console.error(
+            `[RETRY] Attempt ${attempt + 1}/${opts.maxRetries} failed, retrying in ${delayMs}ms`
+          );
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
       }
-
-      await new Promise((resolve) => setTimeout(resolve, delayMs));
     }
-  }
 
-  throw lastError || new Error('Max retries exceeded');
+    throw lastError || new Error('Max retries exceeded');
+  } catch (error) {
+    backendCircuitBreaker.recordFailure();
+    throw error;
+  }
 }
 
 export function sleep(ms: number): Promise<void> {

--- a/mcp-server/src/utils/validate-input.ts
+++ b/mcp-server/src/utils/validate-input.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+import { AppError, ErrorCode } from '../errors/app-error.js';
+
+export function validateInput<T extends z.ZodType>(
+  schema: T,
+  input: unknown
+): z.infer<T> {
+  const result = schema.safeParse(input);
+
+  if (!result.success) {
+    const fieldErrors = result.error.flatten().fieldErrors;
+    const messages = Object.entries(fieldErrors)
+      .map(([field, errors]) => `${field}: ${(errors ?? []).join(', ')}`)
+      .join('; ');
+
+    throw new AppError(
+      ErrorCode.INVALID_INPUT,
+      messages ? `Invalid tool input: ${messages}` : 'Invalid tool input',
+      {
+        details: { fields: fieldErrors },
+        suggestion: 'Verify required fields and types match the tool schema',
+      }
+    );
+  }
+
+  return result.data;
+}


### PR DESCRIPTION
## Summary

- **Circuit Breaker**: Thêm circuit breaker pattern vào MCP server — sau 5 lỗi liên tiếp, fail fast trong 30s thay vì retry storm khi backend down
- **Input Validation (Zod)**: Validate tất cả tool inputs tại MCP layer, trả về lỗi `INVALID_INPUT` rõ ràng trước khi gọi API
- **Per-client Rate Limiting**: Chuyển rate limiter từ global shared sang per-client (100 req/min/client) dựa trên Authorization header hoặc IP
- **Health Check**: MCP server poll backend health trước khi start; thêm endpoint `GET /health` trên Go backend (ngoài `/api/v1/health`)

## Test plan

- [ ] `cd mcp-server && npm run build` — TypeScript compile thành công
- [ ] `go build ./...` — Go backend compile thành công
- [ ] Start backend → Start MCP server → Verify health check pass và server ready
- [ ] Start MCP với backend down → Verify exit với error message rõ ràng
- [ ] Stop backend → Call tool → Verify circuit breaker fail fast (không retry 3 lần)
- [ ] Gọi tool với input sai (missing projectId) → Verify lỗi `INVALID_INPUT`
- [ ] Gửi 110 req/min từ single client → Verify 429 chỉ affect client đó, client khác vẫn hoạt động
- [ ] `curl http://localhost:8098/health` → Verify 200 OK


Made with [Cursor](https://cursor.com)